### PR TITLE
Port improvements from go-htmldate

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,8 +94,8 @@ Python Package                  Precision Recall    Accuracy  F-Score   Time
 articleDateExtractor 0.20       0.817     0.635     0.556     0.714     3.5x
 date_guesser 2.1.4              0.809     0.553     0.489     0.657     21x
 goose3 3.1.6                    0.887     0.441     0.418     0.589     7.7x
-htmldate[all] 0.9.0 (fast)      **0.920** 0.938     0.867     0.929     **1x**
-htmldate[all] 0.9.0 (extensive) 0.911     **1.000** **0.911** **0.953** 1.86x
+htmldate[all] 0.7.2 (fast)      **0.899** 0.917     0.831     0.908     **1x**
+htmldate[all] 0.7.2 (extensive) 0.893     **1.000** **0.893** **0.944** 1.6x
 newspaper3k 0.2.8               0.888     0.407     0.387     0.558     40x
 news-please 1.5.13              0.823     0.660     0.578     0.732     31x
 =============================== ========= ========= ========= ========= =======

--- a/README.rst
+++ b/README.rst
@@ -94,8 +94,8 @@ Python Package                  Precision Recall    Accuracy  F-Score   Time
 articleDateExtractor 0.20       0.817     0.635     0.556     0.714     3.5x
 date_guesser 2.1.4              0.809     0.553     0.489     0.657     21x
 goose3 3.1.6                    0.887     0.441     0.418     0.589     7.7x
-htmldate[all] 0.7.2 (fast)      **0.899** 0.917     0.831     0.908     **1x**
-htmldate[all] 0.7.2 (extensive) 0.893     **1.000** **0.893** **0.944** 1.6x
+htmldate[all] 0.9.0 (fast)      **0.920** 0.938     0.867     0.929     **1x**
+htmldate[all] 0.9.0 (extensive) 0.911     **1.000** **0.911** **0.953** 1.86x
 newspaper3k 0.2.8               0.888     0.407     0.387     0.558     40x
 news-please 1.5.13              0.823     0.660     0.578     0.732     31x
 =============================== ========= ========= ========= ========= =======

--- a/htmldate/core.py
+++ b/htmldate/core.py
@@ -629,29 +629,24 @@ def find_date(htmlobject, extensive_search=True, original_date=False, outputform
     # expressions + text_content
     # first try in pruned tree
     search_tree, discarded = discard_unwanted(deepcopy(tree))
-    for expr in DATE_EXPRESSIONS:
-        dateresult = examine_date_elements(
-            search_tree, expr, outputformat, extensive_search, min_date, max_date
-        )
-        if dateresult is not None:
-            return dateresult
+    dateresult = examine_date_elements(search_tree, DATE_EXPRESSIONS,
+        outputformat, extensive_search, min_date, max_date)
+    if dateresult is not None:
+        return dateresult
+
     # search in discarded parts (currently: footer)
     for subtree in discarded:
-        for expr in DATE_EXPRESSIONS:
-            dateresult = examine_date_elements(
-                subtree, expr, outputformat, extensive_search, min_date, max_date
-            )
-            if dateresult is not None:
-                return dateresult
+        dateresult = examine_date_elements(subtree, DATE_EXPRESSIONS,
+            outputformat, extensive_search, min_date, max_date)
+        if dateresult is not None:
+            return dateresult
 
     # supply more expressions (other languages)
     if extensive_search is True:
-        for expr in ADDITIONAL_EXPRESSIONS:
-            dateresult = examine_date_elements(
-                tree, expr, outputformat, extensive_search, min_date, max_date
-            )
-            if dateresult is not None:
-                return dateresult
+        dateresult = examine_date_elements(tree, ADDITIONAL_EXPRESSIONS,
+            outputformat, extensive_search, min_date, max_date)
+        if dateresult is not None:
+            return dateresult
 
     # try time elements
     time_result = examine_time_elements(

--- a/htmldate/extractors.py
+++ b/htmldate/extractors.py
@@ -118,14 +118,6 @@ COMPLETE_URL = re.compile(r'([0-9]{4})[/-]([0-9]{1,2})[/-]([0-9]{1,2})')
 PARTIAL_URL = re.compile(r'/([0-9]{4})/([0-9]{1,2})/')
 GERMAN_TEXTSEARCH = re.compile(r'''([0-9]{1,2})\.? (Januar|Jänner|Februar|Feber|März|April|
 Mai|Juni|Juli|August|September|Oktober|November|Dezember) ([0-9]{4})'''.replace('\n', ''))
-GENERAL_TEXTSEARCH = re.compile(r'''
-January|February|March|April|May|June|July|August|September|October|November|December|
-Januari|Februari|Maret|Mei|Juni|Juli|Agustus|Oktober|Desember|
-Jan|Feb|Mar|Apr|Jun|Jul|Aug|Sep|Oct|Nov|Dec|
-Januar|Jänner|Februar|Feber|März|Mai|Dezember|
-janvier|février|mars|avril|mai|juin|juillet|aout|septembre|octobre|novembre|décembre|
-Ocak|Şubat|Mart|Nisan|Mayıs|Haziran|Temmuz|Ağustos|Eylül|Ekim|Kasım|Aralık|
-Oca|Şub|Mar|Nis|Haz|Tem|Ağu|Eyl|Eki|Kas|Ara'''.replace('\n', ''))
 JSON_PATTERN_MODIFIED = \
   re.compile(r'"dateModified": ?"([0-9]{4}-[0-9]{2}-[0-9]{2})')
 JSON_PATTERN_PUBLISHED = \
@@ -267,10 +259,6 @@ def regex_parse_de(string):
 def regex_parse_multilingual(string):
     """Try full-text parse for English date elements"""
     # https://github.com/vi3k6i5/flashtext ?
-    
-    # general search
-    if not GENERAL_TEXTSEARCH.search(string):
-        return None
 
     # American English
     match = LONG_MDY_PATTERN.search(string)

--- a/htmldate/extractors.py
+++ b/htmldate/extractors.py
@@ -91,18 +91,24 @@ DISCARD_EXPRESSIONS = [
 ]
 
 # Regex cache
-MDY_PATTERN = re.compile(r'''(January|February|March|April|May|June|July|
-August|September|October|November|December|Jan|Feb|Mar|Apr|Jun|Jul|Aug|Sep|
-Oct|Nov|Dec|Januar|Jänner|Februar|Feber|März|Mai|Juni|Juli|Oktober|Dezember|
+MDY_PATTERN = re.compile(r'''(
+January|February|March|April|May|June|July|August|September|October|November|December|
+Januari|Februari|Maret|Mei|Juni|Juli|Agustus|Oktober|Desember|
+Jan|Feb|Mar|Apr|Jun|Jul|Aug|Sep|Oct|Nov|Dec|
+Januar|Jänner|Februar|Feber|März|Mai|Dezember|
+janvier|février|mars|avril|mai|juin|juillet|aout|septembre|octobre|novembre|décembre|
 Ocak|Şubat|Mart|Nisan|Mayıs|Haziran|Temmuz|Ağustos|Eylül|Ekim|Kasım|Aralık|
-Oca|Şub|Mar|Nis|Haz|Tem|Ağu|Eyl|Eki|Kas|
-Ara) ([0-9]{1,2})(st|nd|rd|th)?,? ([0-9]{4})'''.replace('\n', ''))
-DMY_PATTERN = re.compile(r'''([0-9]{1,2})(st|nd|rd|th)? (of )?(January|
-February|March|April|May|June|July|August|September|October|November|December|
-Jan|Feb|Mar|Apr|Jun|Jul|Aug|Sep|Oct|Nov|Dec|Januar|Jänner|Februar|Feber|März|
-Mai|Juni|Juli|Oktober|Dezember|Ocak|Şubat|Mart|Nisan|Mayıs|Haziran|Temmuz|
-Ağustos|Eylül|Ekim|Kasım|Aralık|Oca|Şub|Mar|Nis|Haz|Tem|Ağu|Eyl|Eki|Kas|
-Ara),? ([0-9]{4})'''.replace('\n', ''))
+Oca|Şub|Mar|Nis|Haz|Tem|Ağu|Eyl|Eki|Kas|Ara
+) ([0-9]{1,2})(st|nd|rd|th)?,? ([0-9]{4})'''.replace('\n', ''))
+DMY_PATTERN = re.compile(r'''([0-9]{1,2})(st|nd|rd|th)? (of )?(
+January|February|March|April|May|June|July|August|September|October|November|December|
+Januari|Februari|Maret|Mei|Juni|Juli|Agustus|Oktober|Desember|
+Jan|Feb|Mar|Apr|Jun|Jul|Aug|Sep|Oct|Nov|Dec|
+Januar|Jänner|Februar|Feber|März|Mai|Dezember|
+janvier|février|mars|avril|mai|juin|juillet|aout|septembre|octobre|novembre|décembre|
+Ocak|Şubat|Mart|Nisan|Mayıs|Haziran|Temmuz|Ağustos|Eylül|Ekim|Kasım|Aralık|
+Oca|Şub|Mar|Nis|Haz|Tem|Ağu|Eyl|Eki|Kas|Ara
+),? ([0-9]{4})'''.replace('\n', ''))
 ENGLISH_DATE = re.compile(r'([0-9]{1,2})/([0-9]{1,2})/([0-9]{2,4})')
 COMPLETE_URL = re.compile(r'([0-9]{4})[/-]([0-9]{1,2})[/-]([0-9]{1,2})')
 PARTIAL_URL = re.compile(r'/([0-9]{4})/([0-9]{1,2})/')
@@ -110,9 +116,12 @@ YMD_PATTERN = re.compile(r'([0-9]{4})-([0-9]{2})-([0-9]{2})')
 DATESTUB_PATTERN = re.compile(r'([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{2,4})')
 GERMAN_TEXTSEARCH = re.compile(r'''([0-9]{1,2})\.? (Januar|Jänner|Februar|Feber|März|April|
 Mai|Juni|Juli|August|September|Oktober|November|Dezember) ([0-9]{4})'''.replace('\n', ''))
-GENERAL_TEXTSEARCH = re.compile(r'''January|February|March|April|May|June|July|
-August|September|October|November|December|Jan|Feb|Mar|Apr|Jun|Jul|Aug|Sep|Oct|
-Nov|Dec|Januar|Jänner|Februar|Feber|März|Mai|Juni|Juli|Oktober|Dezember|
+GENERAL_TEXTSEARCH = re.compile(r'''
+January|February|March|April|May|June|July|August|September|October|November|December|
+Januari|Februari|Maret|Mei|Juni|Juli|Agustus|Oktober|Desember|
+Jan|Feb|Mar|Apr|Jun|Jul|Aug|Sep|Oct|Nov|Dec|
+Januar|Jänner|Februar|Feber|März|Mai|Dezember|
+janvier|février|mars|avril|mai|juin|juillet|aout|septembre|octobre|novembre|décembre|
 Ocak|Şubat|Mart|Nisan|Mayıs|Haziran|Temmuz|Ağustos|Eylül|Ekim|Kasım|Aralık|
 Oca|Şub|Mar|Nis|Haz|Tem|Ağu|Eyl|Eki|Kas|Ara'''.replace('\n', ''))
 JSON_PATTERN_MODIFIED = \
@@ -122,27 +131,35 @@ JSON_PATTERN_PUBLISHED = \
 TIMESTAMP_PATTERN = regex.compile(r'([0-9]{4}-[0-9]{2}-[0-9]{2}|[0-9]{2}\.[0-9]{2}\.[0-9]{4}).[0-9]{2}:[0-9]{2}:[0-9]{2}')
 
 # English + German + Turkish dates cache
-TEXT_MONTHS = {'Januar': '01', 'Jänner': '01', 'January': '01', 'Jan': '01',
-               'Ocak': '01', 'Oca': '01',
-               'Februar': '02', 'Feber': '02', 'February': '02', 'Feb': '02',
-               'Şubat': '02', 'Şub': '02',
-               'März': '03', 'March': '03', 'Mar': '03', 'Mart': '03',
-               'April': '04', 'Apr': '04', 'Nisan': '04', 'Nis': '04',
-               'Mai': '05', 'May': '05', 'Mayıs': '05',
-               'Juni': '06', 'June': '06', 'Jun': '06',
-               'Haziran': '06', 'Haz': '06',
-               'Juli': '07', 'July': '07', 'Jul': '07',
-               'Temmuz': '07', 'Tem': '07',
-               'August': '08', 'Aug': '08',
-               'Ağustos': '08', 'Ağu': '08',
-               'September': '09', 'Sep': '09',
-               'Eylül': '09', 'Eyl': '09',
-               'Oktober': '10', 'October': '10', 'Oct': '10',
-               'Ekim': '10', 'Eki': '10',
-               'November': '11', 'Nov': '11',
-               'Kasım': '11', 'Kas': '11',
-               'Dezember': '12', 'December': '12', 'Dec': '12',
-               'Aralık': '12', 'Ara': '12'}
+TEXT_MONTHS = {
+    # January
+    'Januar': '01', 'Jänner': '01', 'January': '01', 'Januari': '01', 'Jan': '01',
+    'Ocak': '01', 'Oca': '01', 'janvier': '01',
+    # February
+    'Februar': '02', 'Feber': '02', 'February': '02', 'Februari': '02', 'Feb': '02',
+    'Şubat': '02', 'Şub': '02', 'février': '02',
+    # March
+    'März': '03', 'March': '03', 'Maret': '03', 'Mar': '03', 'Mart': '03', 'mars': '03',
+    # April
+    'April': '04', 'Apr': '04', 'Nisan': '04', 'Nis': '04', 'avril': '04',
+    # May
+    'Mai': '05', 'May': '05', 'Mei': '05', 'Mayıs': '05', 'mai': '05',
+    # June
+    'Juni': '06', 'June': '06', 'Jun': '06', 'Haziran': '06', 'Haz': '06', 'juin': '06',
+    # July
+    'Juli': '07', 'July': '07', 'Jul': '07', 'Temmuz': '07', 'Tem': '07', 'juillet': '07',
+    # August
+    'August': '08', 'Agustus': '08', 'Aug': '08', 'Ağustos': '08', 'Ağu': '08', 'aout': '08',
+    # September
+    'September': '09', 'Sep': '09', 'Eylül': '09', 'Eyl': '09', 'septembre': '09',
+    # October
+    'Oktober': '10', 'October': '10', 'Oct': '10', 'Ekim': '10', 'Eki': '10', 'octobre': '10',
+    # November
+    'November': '11', 'Nov': '11', 'Kasım': '11', 'Kas': '11', 'novembre': '11',
+    # December
+    'Dezember': '12', 'December': '12', 'Desember': '12', 'Dec': '12', 'Aralık': '12',
+    'Ara': '12', 'décembre': '12'
+}
 
 TEXT_DATE_PATTERN = re.compile(r'[.:,_/ -]|^[0-9]+$')
 NO_TEXT_DATE_PATTERN = re.compile(r'[0-9]{3,}\D+[0-9]{3,}|[0-9]{2}:[0-9]{2}(:| )|\D*[0-9]{4}\D*$')

--- a/htmldate/extractors.py
+++ b/htmldate/extractors.py
@@ -72,7 +72,7 @@ DATE_EXPRESSIONS = """
     contains(@class, 'submitted') or contains(@class, 'updated') or contains(@class, 'created-post')
     or contains(@id, 'post-timestamp') or contains(@class, 'post-timestamp')]
 	|
-    //*[contains(@id, 'lastmod') or contains(@itemprop, 'date') or
+    .//*[contains(@id, 'lastmod') or contains(@itemprop, 'date') or
     contains(@class, 'time') or contains(@id, 'metadata') or contains(@id, 'publish')]
 	|
     .//footer

--- a/htmldate/extractors.py
+++ b/htmldate/extractors.py
@@ -52,13 +52,15 @@ from .validators import convert_date, date_validator
 
 LOGGER = logging.getLogger(__name__)
 
-DATE_EXPRESSIONS = [
-    """.//*[contains(@id, 'date') or contains(@id, 'Date') or
+DATE_EXPRESSIONS = """
+	.//*[contains(@id, 'date') or contains(@id, 'Date') or
     contains(@id, 'datum') or contains(@id, 'Datum') or contains(@id, 'time')
-    or contains(@class, 'post-meta-time')]""",
-    """.//*[contains(@class, 'date') or contains(@class, 'Date')
-    or contains(@class, 'datum') or contains(@class, 'Datum')]""",
-    """.//*[contains(@class, 'postmeta') or contains(@class, 'post-meta')
+    or contains(@class, 'post-meta-time')]
+	|
+    .//*[contains(@class, 'date') or contains(@class, 'Date')
+    or contains(@class, 'datum') or contains(@class, 'Datum')]
+	|
+    .//*[contains(@class, 'postmeta') or contains(@class, 'post-meta')
     or contains(@class, 'entry-meta') or contains(@class, 'entry-date') or contains(@class, 'postMeta')
     or contains(@class, 'post_meta') or contains(@class, 'post__meta') or
     contains(@class, 'article__date') or contains(@class, 'post_detail') or @class='meta'
@@ -68,27 +70,28 @@ DATE_EXPRESSIONS = [
     contains(@class, 'dateline') or contains(@class, 'subline')
     or contains(@class, 'published') or contains(@class, 'posted') or
     contains(@class, 'submitted') or contains(@class, 'updated') or contains(@class, 'created-post')
-    or contains(@id, 'post-timestamp') or contains(@class, 'post-timestamp')]""",
-    """.//*[contains(@id, 'lastmod') or contains(@itemprop, 'date') or
-    contains(@class, 'time') or contains(@id, 'metadata') or contains(@id, 'publish')]""",
-    ".//footer|.//*[@class='post-footer' or @class='footer' or @id='footer']",
-    ".//small",
-    """.//*[contains(@class, 'author') or contains(@class, 'autor') or
+    or contains(@id, 'post-timestamp') or contains(@class, 'post-timestamp')]
+	|
+    //*[contains(@id, 'lastmod') or contains(@itemprop, 'date') or
+    contains(@class, 'time') or contains(@id, 'metadata') or contains(@id, 'publish')]
+	|
+    .//footer
+	|
+	.//*[@class='post-footer' or @class='footer' or @id='footer']
+	|
+    .//small
+	|
+    .//*[contains(@class, 'author') or contains(@class, 'autor') or
     contains(@class, 'field-content') or @class='meta' or
     contains(@class, 'info') or contains(@class, 'fa-clock-o') or contains(@class, 'fa-calendar') or
-    contains(@class, 'publication')]""",
-]
+    contains(@class, 'publication')]"""
 
 # supply more expressions for more languages
-ADDITIONAL_EXPRESSIONS = [
-    ".//*[contains(@class, 'fecha') or contains(@class, 'parution')]",
-]
+ADDITIONAL_EXPRESSIONS = ".//*[contains(@class, 'fecha') or contains(@class, 'parution')]"
 
 # discard parts of the webpage
-DISCARD_EXPRESSIONS = [
-    './/footer',
-    './/*[(self::div or self::section)][@id="footer" or @class="footer"]',
-]
+DISCARD_EXPRESSIONS = """.//footer
+	|.//*[(self::div or self::section)][@id="footer" or @class="footer"]"""
 
 # Regex cache
 YMD_NO_SEP_PATTERN = re.compile(r'(?:\D|^)(\d{8})(?:\D|$)')
@@ -188,10 +191,9 @@ SIMPLE_PATTERN = re.compile(r'\D(199[0-9]|20[0-9]{2})\D')
 def discard_unwanted(tree):
     '''Delete unwanted sections of an HTML document and return them as a list'''
     my_discarded = []
-    for expr in DISCARD_EXPRESSIONS:
-        for subtree in tree.xpath(expr):
-            my_discarded.append(subtree)
-            subtree.getparent().remove(subtree)
+    for subtree in tree.xpath(DISCARD_EXPRESSIONS):
+        my_discarded.append(subtree)
+        subtree.getparent().remove(subtree)
     return tree, my_discarded
 
 

--- a/htmldate/extractors.py
+++ b/htmldate/extractors.py
@@ -91,7 +91,12 @@ DISCARD_EXPRESSIONS = [
 ]
 
 # Regex cache
-MDY_PATTERN = re.compile(r'''(
+YMD_NO_SEP_PATTERN = re.compile(r'(?:\D|^)(\d{8})(?:\D|$)')
+YMD_PATTERN = re.compile(r'(?:\D|^)(\d{4})[\-/.](\d{1,2})[\-/.](\d{1,2})(?:\D|$)')
+DMY_PATTERN = re.compile(r'(?:\D|^)(\d{1,2})[\-/.](\d{1,2})[\-/.](\d{2,4})(?:\D|$)')
+YM_PATTERN = re.compile(r'(?:\D|^)(\d{4})[\-/.](\d{1,2})(?:\D|$)')
+MY_PATTERN = re.compile(r'(?:\D|^)(\d{1,2})[\-/.](\d{4})(?:\D|$)')
+LONG_MDY_PATTERN = re.compile(r'''(
 January|February|March|April|May|June|July|August|September|October|November|December|
 Januari|Februari|Maret|Mei|Juni|Juli|Agustus|Oktober|Desember|
 Jan|Feb|Mar|Apr|Jun|Jul|Aug|Sep|Oct|Nov|Dec|
@@ -100,7 +105,7 @@ janvier|février|mars|avril|mai|juin|juillet|aout|septembre|octobre|novembre|dé
 Ocak|Şubat|Mart|Nisan|Mayıs|Haziran|Temmuz|Ağustos|Eylül|Ekim|Kasım|Aralık|
 Oca|Şub|Mar|Nis|Haz|Tem|Ağu|Eyl|Eki|Kas|Ara
 ) ([0-9]{1,2})(st|nd|rd|th)?,? ([0-9]{4})'''.replace('\n', ''))
-DMY_PATTERN = re.compile(r'''([0-9]{1,2})(st|nd|rd|th)? (of )?(
+LONG_DMY_PATTERN = re.compile(r'''([0-9]{1,2})(st|nd|rd|th)? (of )?(
 January|February|March|April|May|June|July|August|September|October|November|December|
 Januari|Februari|Maret|Mei|Juni|Juli|Agustus|Oktober|Desember|
 Jan|Feb|Mar|Apr|Jun|Jul|Aug|Sep|Oct|Nov|Dec|
@@ -109,11 +114,8 @@ janvier|février|mars|avril|mai|juin|juillet|aout|septembre|octobre|novembre|dé
 Ocak|Şubat|Mart|Nisan|Mayıs|Haziran|Temmuz|Ağustos|Eylül|Ekim|Kasım|Aralık|
 Oca|Şub|Mar|Nis|Haz|Tem|Ağu|Eyl|Eki|Kas|Ara
 ),? ([0-9]{4})'''.replace('\n', ''))
-ENGLISH_DATE = re.compile(r'([0-9]{1,2})/([0-9]{1,2})/([0-9]{2,4})')
 COMPLETE_URL = re.compile(r'([0-9]{4})[/-]([0-9]{1,2})[/-]([0-9]{1,2})')
 PARTIAL_URL = re.compile(r'/([0-9]{4})/([0-9]{1,2})/')
-YMD_PATTERN = re.compile(r'([0-9]{4})-([0-9]{2})-([0-9]{2})')
-DATESTUB_PATTERN = re.compile(r'([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{2,4})')
 GERMAN_TEXTSEARCH = re.compile(r'''([0-9]{1,2})\.? (Januar|Jänner|Februar|Feber|März|April|
 Mai|Juni|Juli|August|September|Oktober|November|Dezember) ([0-9]{4})'''.replace('\n', ''))
 GENERAL_TEXTSEARCH = re.compile(r'''
@@ -237,7 +239,6 @@ def extract_partial_url_date(testurl, outputformat):
 
 def regex_parse(string):
     """Full-text parse using a series of regular expressions"""
-    dateobject = None
     dateobject = regex_parse_de(string)
     if dateobject is None:
         dateobject = regex_parse_multilingual(string)
@@ -266,104 +267,121 @@ def regex_parse_de(string):
 def regex_parse_multilingual(string):
     """Try full-text parse for English date elements"""
     # https://github.com/vi3k6i5/flashtext ?
-    # numbers
-    match = ENGLISH_DATE.search(string)
+    
+    # general search
+    if not GENERAL_TEXTSEARCH.search(string):
+        return None
+
+    # American English
+    match = LONG_MDY_PATTERN.search(string)
     if match:
-        day, month, year = match.group(2), match.group(1), match.group(3)
+        day = match.group(2)
+        month = TEXT_MONTHS[match.group(1)]
+        year = match.group(4)
+
+    # multilingual day-month-year pattern
     else:
-        # general search
-        if not GENERAL_TEXTSEARCH.search(string):
-            return None
-        # American English
-        match = MDY_PATTERN.search(string)
+        match = LONG_DMY_PATTERN.search(string)
         if match:
-            day, month, year = match.group(2), TEXT_MONTHS[match.group(1)], \
-                               match.group(4)
-        # multilingual day-month-year pattern
+            day = match.group(1)
+            month = TEXT_MONTHS[match.group(4)]
+            year = match.group(5)
         else:
-            match = DMY_PATTERN.search(string)
-            if match:
-                day, month, year = match.group(1), TEXT_MONTHS[match.group(4)], \
-                                   match.group(5)
-            else:
-                return None
+            return None
+
     # process and return
-    if len(year) == 2:
-        year = '20' + year
     try:
-        dateobject = datetime.date(int(year), int(month), int(day))
+        intYear = int(year)
+        intMonth = int(month)
+        intDay = int(day)
+
+        if intYear < 100:
+            if intYear >= 90: intYear += 1900
+            else: intYear += 2000
+
+        dateobject = datetime.date(intYear, intMonth, intDay)
     except ValueError:
         return None
-    LOGGER.debug('English text parse: %s', dateobject)
+
+    LOGGER.debug('multilingual text found: %s', dateobject)
     return dateobject
 
-
+# TODO
 def custom_parse(string, outputformat, extensive_search, min_date, max_date):
     """Try to bypass the slow dateparser"""
     LOGGER.debug('custom parse test: %s', string)
-    # '201709011234' not covered by dateparser # regex was too slow
-    if string[0:8].isdigit():
+    
+	# Use regex first
+	# 1. Try YYYYMMDD first
+    match = YMD_NO_SEP_PATTERN.search(string)
+    if match:
         try:
-            candidate = datetime.date(int(string[:4]),
-                                      int(string[4:6]),
-                                      int(string[6:8]))
+            tmp = match.group(0)
+            year, month, day = int(tmp[:4]), int(tmp[4:6]), int(tmp[6:8])
+            candidate = datetime.date(year, month, day)
         except ValueError:
-            return None
-        if date_validator(candidate, '%Y-%m-%d') is True:
-            LOGGER.debug('ymd match: %s', candidate)
-            return convert_date(candidate, '%Y-%m-%d', outputformat)
-    # much faster
-    if string[0:4].isdigit():
-        # try speedup with ciso8601 (if installed)
-        try:
-            if extensive_search is True:
-                result = parse_datetime(string)
-            # speed-up by ignoring time zone info if ciso8601 is installed
-            else:
-                result = parse_datetime_as_naive(string)
-            if date_validator(result, outputformat, earliest=min_date, latest=max_date) is True:
-                LOGGER.debug('parsing result: %s', result)
-                return result.strftime(outputformat)
-        except (OverflowError, TypeError, ValueError):
-            LOGGER.debug('parsing error: %s', string)
-    # %Y-%m-%d search
+            LOGGER.debug('YYYYMMDD value error: %s', match.group(0))
+        else:
+            if date_validator(candidate, '%Y-%m-%d') is True:
+                LOGGER.debug('YYYYMMDD match: %s', candidate)
+                return convert_date(candidate, '%Y-%m-%d', outputformat)
+
+    # 2. Try Y-M-D pattern since it's the one used in ISO-8601
     match = YMD_PATTERN.search(string)
     if match:
         try:
-            candidate = datetime.date(int(match.group(1)),
-                                      int(match.group(2)),
-                                      int(match.group(3)))
+            year = int(match.group(1))
+            month = int(match.group(2))
+            day = int(match.group(3))
+            candidate = datetime.date(year, month, day)
         except ValueError:
-            LOGGER.debug('value error: %s', match.group(0))
+            LOGGER.debug('Y-M-D value error: %s', match.group(0))
         else:
             if date_validator(candidate, '%Y-%m-%d') is True:
-                LOGGER.debug('ymd match: %s', candidate)
+                LOGGER.debug('Y-M-D match: %s', candidate)
                 return convert_date(candidate, '%Y-%m-%d', outputformat)
-    # faster than fire dateparser at once
-    datestub = DATESTUB_PATTERN.search(string)
-    if datestub and len(datestub.group(3)) in (2, 4):
+
+	# 3. Try the D-M-Y pattern since it's the most common date format in the world
+    match = DMY_PATTERN.search(string)
+    if match:
         try:
-            if len(datestub.group(3)) == 2:
-                candidate = datetime.date(int('20' + datestub.group(3)),
-                                          int(datestub.group(2)),
-                                          int(datestub.group(1)))
-            elif len(datestub.group(3)) == 4:
-                candidate = datetime.date(int(datestub.group(3)),
-                                          int(datestub.group(2)),
-                                          int(datestub.group(1)))
+            day = int(match.group(1))
+            month = int(match.group(2))
+            year = int(match.group(3))
+
+            # Append year if necessary
+            if year < 100:
+                if year >= 90: year += 1900
+                else: year += 2000
+            
+            # If month is more than 12, swap it with the day
+            if month > 12 and day <= 12:
+                day, month = month, day
+
+            candidate = datetime.date(year, month, day)
         except ValueError:
-            LOGGER.debug('value error: %s', datestub.group(0))
+            LOGGER.debug('D-M-Y value error: %s', match.group(0))
         else:
-            # test candidate
             if date_validator(candidate, '%Y-%m-%d') is True:
-                LOGGER.debug('D.M.Y match: %s', candidate)
+                LOGGER.debug('D-M-Y match: %s', candidate)
                 return convert_date(candidate, '%Y-%m-%d', outputformat)
-    # text match
+
+	# 4. Try the Y-M pattern
+    match = YM_PATTERN.search(string)
+    if match:
+        try:
+            year = int(match.group(1))
+            month = int(match.group(2))
+            candidate = datetime.date(year, month, 1)
+        except ValueError:
+            LOGGER.debug('Y-M value error: %s', match.group(0))
+        else:
+            if date_validator(candidate, '%Y-%m-%d') is True:
+                LOGGER.debug('Y-M match: %s', candidate)
+                return convert_date(candidate, '%Y-%m-%d', outputformat)
+
+	# 5. Try the other regex pattern
     dateobject = regex_parse(string)
-    # copyright match?
-    #if dateobject is None:
-    # © Janssen-Cilag GmbH 2014-2019. https://www.krebsratgeber.de/artikel/was-macht-eine-zelle-zur-krebszelle
-    # examine
     if dateobject is not None:
         try:
             if date_validator(dateobject, outputformat) is True:
@@ -371,6 +389,7 @@ def custom_parse(string, outputformat, extensive_search, min_date, max_date):
                 return dateobject.strftime(outputformat)
         except ValueError as err:
             LOGGER.debug('value error during conversion: %s %s', string, err)
+
     return None
 
 
@@ -397,25 +416,33 @@ def try_ymd_date(string, outputformat, extensive_search, min_date, max_date):
     """Use a series of heuristics and rules to parse a potential date expression"""
     # discard on formal criteria
     # list(filter(str.isdigit, string))
+
+    # if string less than 6 runes, stop
     if not string or len(string) < 6:
         return None
+
+    # count how many digit number in this string
     digits_num = len([c for c in string if c.isdigit()])
     if not 4 <= digits_num <= 18:
         return None
-    # just time/single year or digits, not a date
+
+    # check if string only contains time/single year or digits and not a date
     if not TEXT_DATE_PATTERN.search(string) or NO_TEXT_DATE_PATTERN.match(string):
         return None
-    # faster
+
+    # try to parse using the faster method
     customresult = custom_parse(string, outputformat, extensive_search, min_date, max_date)
     if customresult is not None:
         return customresult
-    # slow but extensive search
+
+    # use slow but extensive search
     if extensive_search is True:
         # send to date parser
         dateparser_result = external_date_parser(string, outputformat)
         if dateparser_result is not None:
             if date_validator(dateparser_result, outputformat, earliest=min_date, latest=max_date):
                 return dateparser_result
+
     return None
 
 

--- a/htmldate/extractors.py
+++ b/htmldate/extractors.py
@@ -53,13 +53,13 @@ from .validators import convert_date, date_validator
 LOGGER = logging.getLogger(__name__)
 
 DATE_EXPRESSIONS = """
-	.//*[contains(@id, 'date') or contains(@id, 'Date') or
+    .//*[contains(@id, 'date') or contains(@id, 'Date') or
     contains(@id, 'datum') or contains(@id, 'Datum') or contains(@id, 'time')
     or contains(@class, 'post-meta-time')]
-	|
+    |
     .//*[contains(@class, 'date') or contains(@class, 'Date')
     or contains(@class, 'datum') or contains(@class, 'Datum')]
-	|
+    |
     .//*[contains(@class, 'postmeta') or contains(@class, 'post-meta')
     or contains(@class, 'entry-meta') or contains(@class, 'entry-date') or contains(@class, 'postMeta')
     or contains(@class, 'post_meta') or contains(@class, 'post__meta') or
@@ -71,16 +71,16 @@ DATE_EXPRESSIONS = """
     or contains(@class, 'published') or contains(@class, 'posted') or
     contains(@class, 'submitted') or contains(@class, 'updated') or contains(@class, 'created-post')
     or contains(@id, 'post-timestamp') or contains(@class, 'post-timestamp')]
-	|
+    |
     .//*[contains(@id, 'lastmod') or contains(@itemprop, 'date') or
     contains(@class, 'time') or contains(@id, 'metadata') or contains(@id, 'publish')]
-	|
+    |
     .//footer
-	|
-	.//*[@class='post-footer' or @class='footer' or @id='footer']
-	|
+    |
+    .//*[@class='post-footer' or @class='footer' or @id='footer']
+    |
     .//small
-	|
+    |
     .//*[contains(@class, 'author') or contains(@class, 'autor') or
     contains(@class, 'field-content') or @class='meta' or
     contains(@class, 'info') or contains(@class, 'fa-clock-o') or contains(@class, 'fa-calendar') or
@@ -91,7 +91,7 @@ ADDITIONAL_EXPRESSIONS = ".//*[contains(@class, 'fecha') or contains(@class, 'pa
 
 # discard parts of the webpage
 DISCARD_EXPRESSIONS = """.//footer
-	|.//*[(self::div or self::section)][@id="footer" or @class="footer"]"""
+    |.//*[(self::div or self::section)][@id="footer" or @class="footer"]"""
 
 # Regex cache
 YMD_NO_SEP_PATTERN = re.compile(r'(?:\D|^)(\d{8})(?:\D|$)')
@@ -301,8 +301,8 @@ def custom_parse(string, outputformat, extensive_search, min_date, max_date):
     """Try to bypass the slow dateparser"""
     LOGGER.debug('custom parse test: %s', string)
     
-	# Use regex first
-	# 1. Try YYYYMMDD first
+    # Use regex first
+    # 1. Try YYYYMMDD first
     match = YMD_NO_SEP_PATTERN.search(string)
     if match:
         try:
@@ -331,7 +331,7 @@ def custom_parse(string, outputformat, extensive_search, min_date, max_date):
                 LOGGER.debug('Y-M-D match: %s', candidate)
                 return convert_date(candidate, '%Y-%m-%d', outputformat)
 
-	# 3. Try the D-M-Y pattern since it's the most common date format in the world
+    # 3. Try the D-M-Y pattern since it's the most common date format in the world
     match = DMY_PATTERN.search(string)
     if match:
         try:
@@ -356,7 +356,7 @@ def custom_parse(string, outputformat, extensive_search, min_date, max_date):
                 LOGGER.debug('D-M-Y match: %s', candidate)
                 return convert_date(candidate, '%Y-%m-%d', outputformat)
 
-	# 4. Try the Y-M pattern
+    # 4. Try the Y-M pattern
     match = YM_PATTERN.search(string)
     if match:
         try:
@@ -370,7 +370,7 @@ def custom_parse(string, outputformat, extensive_search, min_date, max_date):
                 LOGGER.debug('Y-M match: %s', candidate)
                 return convert_date(candidate, '%Y-%m-%d', outputformat)
 
-	# 5. Try the other regex pattern
+    # 5. Try the other regex pattern
     dateobject = regex_parse(string)
     if dateobject is not None:
         try:

--- a/htmldate/settings.py
+++ b/htmldate/settings.py
@@ -24,7 +24,7 @@ LATEST_POSSIBLE = datetime.date.today()
 MAX_YEAR = LATEST_POSSIBLE.year
 
 # set an upper limit to the number of candidates
-MAX_POSSIBLE_CANDIDATES = 100
+MAX_POSSIBLE_CANDIDATES = 300
 
 # HTML_CLEANER config # http://lxml.de/api/lxml.html.clean.Cleaner-class.html
 HTML_CLEANER = Cleaner()

--- a/htmldate/settings.py
+++ b/htmldate/settings.py
@@ -24,7 +24,7 @@ LATEST_POSSIBLE = datetime.date.today()
 MAX_YEAR = LATEST_POSSIBLE.year
 
 # set an upper limit to the number of candidates
-MAX_POSSIBLE_CANDIDATES = 300
+MAX_POSSIBLE_CANDIDATES = 150
 
 # HTML_CLEANER config # http://lxml.de/api/lxml.html.clean.Cleaner-class.html
 HTML_CLEANER = Cleaner()

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -291,7 +291,7 @@ def test_exact_date():
     assert find_date(load_mock_page('https://www.oberstdorf-resort.de/interaktiv/blog/unser-kraeutergarten-wannenkopfhuette.html')) == '2018-06-20'
     assert find_date(load_mock_page('https://www.wienbadminton.at/news/119843/Come-Together')) == '2018-05-06'
     assert find_date(load_mock_page('https://www.ldt.de/ldtblog/fall-in-love-with-black/')) == '2017-08-08'
-    assert find_date(load_mock_page('https://paris-luttes.info/quand-on-comprend-que-les-grenades-12355'), original_date=True) == '2019-07-03' # should be '2019-06-29'
+    assert find_date(load_mock_page('https://paris-luttes.info/quand-on-comprend-que-les-grenades-12355'), original_date=True) == '2019-06-29'
     assert find_date(load_mock_page('https://verfassungsblog.de/the-first-decade/')) == '2019-07-13'
     assert find_date(load_mock_page('https://cric-grenoble.info/infos-locales/article/putsh-en-cours-a-radio-kaleidoscope-1145')) == '2019-06-09'
     assert find_date(load_mock_page('https://www.sebastian-kurz.at/magazin/wasserstoff-als-schluesseltechnologie')) == '2019-07-30'

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -386,8 +386,8 @@ def test_try_ymd_date():
     assert try_ymd_date('Am 1. September 2017 um 15:36 Uhr schrieb', OUTPUTFORMAT, True, MIN_DATE, LATEST_POSSIBLE) == '2017-09-01'
     assert try_ymd_date('Fri - September 1 - 2017', OUTPUTFORMAT, True, MIN_DATE, LATEST_POSSIBLE) == '2017-09-01'
     assert try_ymd_date('1.9.2017', OUTPUTFORMAT, True, MIN_DATE, LATEST_POSSIBLE) == '2017-09-01'
-    assert try_ymd_date('1/9/17', OUTPUTFORMAT, True, MIN_DATE, LATEST_POSSIBLE) == '2017-01-09' # assuming MDY format
-    assert try_ymd_date('201709011234', OUTPUTFORMAT, True, MIN_DATE, LATEST_POSSIBLE) == '2017-09-01'
+    assert try_ymd_date('1/9/17', OUTPUTFORMAT, True, MIN_DATE, LATEST_POSSIBLE) == '2017-09-01' # assuming MDY format
+    assert try_ymd_date('201709011234', OUTPUTFORMAT, True, MIN_DATE, LATEST_POSSIBLE) is None
     # other output format
     assert try_ymd_date('1.9.2017', '%d %B %Y', True, MIN_DATE, LATEST_POSSIBLE) == '01 September 2017'
     # wrong
@@ -435,9 +435,9 @@ def test_regex_parse():
     assert regex_parse('3rd Tuesday in March') is None
     assert regex_parse('Mart 26, 2019') is not None
     assert regex_parse('Salı, Mart 26, 2019') is not None
-    assert regex_parse('3/14/2016') is not None
     assert regex_parse('36/14/2016') is None
     assert custom_parse('12122004', OUTPUTFORMAT, False, MIN_DATE, LATEST_POSSIBLE) is None
+    assert custom_parse('3/14/2016', OUTPUTFORMAT, False, MIN_DATE, LATEST_POSSIBLE) is not None
     assert custom_parse('20041212', OUTPUTFORMAT, False, MIN_DATE, LATEST_POSSIBLE) is not None
     assert custom_parse('20041212', OUTPUTFORMAT, True, MIN_DATE, LATEST_POSSIBLE) is not None
     assert custom_parse('1212-20-04', OUTPUTFORMAT, False, MIN_DATE, LATEST_POSSIBLE) is None

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -387,7 +387,7 @@ def test_try_ymd_date():
     assert try_ymd_date('Fri - September 1 - 2017', OUTPUTFORMAT, True, MIN_DATE, LATEST_POSSIBLE) == '2017-09-01'
     assert try_ymd_date('1.9.2017', OUTPUTFORMAT, True, MIN_DATE, LATEST_POSSIBLE) == '2017-09-01'
     assert try_ymd_date('1/9/17', OUTPUTFORMAT, True, MIN_DATE, LATEST_POSSIBLE) == '2017-09-01' # assuming MDY format
-    assert try_ymd_date('201709011234', OUTPUTFORMAT, True, MIN_DATE, LATEST_POSSIBLE) is None
+    assert try_ymd_date('201709011234', OUTPUTFORMAT, True, MIN_DATE, LATEST_POSSIBLE) == '2017-09-01'
     # other output format
     assert try_ymd_date('1.9.2017', '%d %B %Y', True, MIN_DATE, LATEST_POSSIBLE) == '01 September 2017'
     # wrong


### PR DESCRIPTION
## Overview

While porting this library into Go language, I've tried to made some improvements to make the extraction more accurate. After more testing, it looks like those improvements are good and stable enough to use so I decided to implement those improvements back to Python here.

## Changes

There are three main changes in this PR:

1. **Add French and Indonesian language to regular expressions that used to parse long date string.**

	This is done to fix `htmldate` failed to extract date from `paris-luttes.info.html` which uses French language. Since I added a new language to the regular expressions, I decided to add Indonesian language as well.

2. **Improve `custom_parse`.**

	Now it works by trying to parse the string using several formats with following priority:

	- YYYYMMDD pattern
	- YYYY-MM-DD (ISO-8601)
	- DD-MM-YYYY (most common used date format according to Wikipedia)
	- YYYY-MM pattern
	- Regex patterns

3. **Merge xpath selectors from array of strings into a single string.**

	This is done to fix `htmldate` extracted the wrong date for `wolfsrebellen-netz.forumieren.com.regeln.html`. Consider HTML document like this:

	```html
	<div>
		<h1>Some Title</h1>
		<p class="author">By Joestar at 2020/12/12, 10:11 AM</p>
		<p>Lorem ipsum dolor sit amet.</p>
		<p>Dolorum explicabo quos voluptas voluptates?</p>
		<p class="current-time">Current date and time: 2021/07/14, 09:00 PM</p>
	</div>
	```

	In document above, there are two dates: one in element with class `"author"` and the other in element with class `"current-time"`.

	In the original code, `htmldate` will pick the date from element in `"current-time"` even though it's occured later in the document. This is because currently `DATE_EXPRESSIONS` is created as array of Xpath selectors, and in that array element with classes that contains `time` is given more priority than element with classes that contains `author`.

	To fix this, I've converted `DATE_EXPRESSIONS` and other Xpath selectors from array of strings into a single string. This way every rules inside the expressions has same priority, so now the `<p class="author">` will be selected first.

## Result

Here is the result of comparison test for the original `htmldate`:

|             Package            | Precision | Recall | Accuracy | F-Score | Speed (s) |
|:------------------------------:|:---------:|:------:|:--------:|:-------:|:---------:|
|        `htmldate` fast         |   0.899   |  0.917 |   0.831  |  0.908  |   1.038   |
|      `htmldate` extensive      |   0.893   |  1.000 |   0.893  |  0.944  |   2.219   |

And here is after this PR:

|             Package            | Precision | Recall | Accuracy | F-Score | Speed (s) |
|:------------------------------:|:---------:|:------:|:--------:|:-------:|:---------:|
|        `htmldate` fast         |   0.920   |  0.938 |   0.867  |  0.929  |   1.579   |
|      `htmldate` extensive      |   0.911   |  1.000 |   0.911  |  0.953  |   2.807   |

So there is a slight increase in accuracy, however the extraction speed become slower (around 1.5x slower than the original).

## Additional Notes

I've not added it to this PR, however since `custom_parse` has been improved, from what I test we can safely remove `external_date_parser` without any performance loss. Here is the result of comparison test after `external_date_parser` removed:

|             Package            | Precision | Recall | Accuracy | F-Score | Speed (s) |
|:------------------------------:|:---------:|:------:|:--------:|:-------:|:---------:|
|        `htmldate` fast         |   0.920   |  0.938 |   0.867  |  0.929  |   1.678   |
|      `htmldate` extensive      |   0.911   |  1.000 |   0.911  |  0.953  |   1.816   |

So the accuracy is still the same, however the extraction speed for extensive mode become a lot faster (now only 1.08x slower than the fast mode) so we might be able to make the extensive mode as default. Might need more tests though.