### PR TITLE
Added support to meta tag citation publication_date

### DIFF
--- a/htmldate/core.py
+++ b/htmldate/core.py
@@ -49,7 +49,7 @@ DATE_ATTRIBUTES = set([
                   'originalpublicationdate', 'parsely-pub-date',
                   'pubdate', 'publishdate', 'publish_date',
                   'published-date', 'publication_date', 'sailthru.date',
-                  'timestamp',
+                  'timestamp', 'citation_publication_date',
                   'article:published_time', 'bt:pubdate', 'datecreated',
                   'dateposted', 'datepublished', 'dc:created', 'dc:date',
                   'og:article:published_time', 'og:published_time',

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -179,6 +179,7 @@ def test_exact_date():
     assert find_date('<html><head><meta property="OG:Updated_Time" content="2017-09-01"/></head><body></body></html>', extensive_search=False) == '2017-09-01'
     assert find_date('<html><head><Meta Property="og:updated_time" content="2017-09-01"/></head><body></body></html>', extensive_search=False) == '2017-09-01'
     assert find_date('<html><head><meta name="created" content="2017-01-09"/></head><body></body></html>') == '2017-01-09'
+    assert find_date('<html><head><meta name="citation_publication_date" content="2017-01-09"/></head><body></body></html>') == '2017-01-09'
     assert find_date('<html><head><meta itemprop="copyrightyear" content="2017"/></head><body></body></html>') == '2017-01-01'
 
     # original date


### PR DESCRIPTION
I added support to meta tag citation as explain in [Google Scholar]( https://scholar.google.com/intl/en/scholar/inclusion.html#indexing) 

`<meta name="citation_publication_date" content="2021/04/05" />`