### PR TITLE
add new itemprop attr for searching date in header

### DIFF
--- a/htmldate/core.py
+++ b/htmldate/core.py
@@ -74,7 +74,7 @@ NON_DIGITS_REGEX = re.compile(r'\D+$')
 GER_STRIP_REGEX = re.compile(r'^am ')
 
 LAST_MODIFIED = {'lastmodified', 'last-modified'}
-ITEMPROP_ATTRS = {'datecreated', 'datepublished', 'pubyear'}
+ITEMPROP_ATTRS = {'datecreated', 'datepublished', 'pubyear', 'dateupdate'}
 CLASS_ATTRS = {'date-published', 'published', 'time published'}
 
 

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -226,6 +226,8 @@ def test_exact_date():
     assert find_date('<html><head><meta pubdate="pubDate" content="2018-02-06"/></head><body></body></html>') == '2018-02-06'
     assert find_date('<html><head><meta itemprop="DateModified" datetime="2018-02-06"/></head><body></body></html>') == '2018-02-06'
     assert find_date('<html><head><meta name="DC.Issued" content="2021-07-13"/></head><body></body></html>') == '2021-07-13'
+    assert find_date('<html><head><meta itemprop="dateUpdate" datetime="2018-02-06"/></head><body></body></html>', original_date=True) == '2018-02-06'
+    assert find_date('<html><head><meta itemprop="dateUpdate" datetime="2018-02-06"/></head><body></body></html>', original_date=False) == '2018-02-06'
 
     ## time in document body
     assert find_date(load_mock_page('https://www.facebook.com/visitaustria/'), original_date=True) == '2017-10-06'


### PR DESCRIPTION
add 'dateupdate' to ITEMPROP_ATTRS for searching date in header. This attr is used in may pages, such as Baidu Baijiahao`https://baijiahao.baidu.com/s?id=1725716042496616928&wfr=spider&for=pc`.