### PR TITLE
Support min_date/max_date as datetimes or datetime strings

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -220,9 +220,9 @@ For usage instructions see ``htmldate -h``:
                               name of input file for batch processing (similar to wget -i)
         --original            original date prioritized
         -min MINDATE, --mindate MINDATE
-                              earliest acceptable date (YYYY-MM-DD)
+                              earliest acceptable date (ISO 8601 YMD)
         -max MAXDATE, --maxdate MAXDATE
-                              latest acceptable date (YYYY-MM-DD)
+                              latest acceptable date (ISO 8601 YMD)
         -u URL, --URL URL     custom URL download
         -v, --verbose         increase output verbosity
         --version             show version information and exit

--- a/htmldate/__init__.py
+++ b/htmldate/__init__.py
@@ -11,6 +11,7 @@ __version__ = "1.4.1"
 
 
 import logging
+from datetime import datetime
 
 try:
     datetime.fromisoformat  # type: ignore[attr-defined]

--- a/htmldate/__init__.py
+++ b/htmldate/__init__.py
@@ -12,6 +12,13 @@ __version__ = "1.4.1"
 
 import logging
 
+try:
+    datetime.fromisoformat  # type: ignore[attr-defined]
+except AttributeError:  # Python 3.6
+    from backports.datetime_fromisoformat import MonkeyPatch  # type: ignore
+
+    MonkeyPatch.patch_fromisoformat()
+
 from .core import find_date
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/htmldate/cli.py
+++ b/htmldate/cli.py
@@ -63,10 +63,10 @@ def parse_args(args: Any) -> Any:
         "--original", help="original date prioritized", action="store_true"
     )
     argsparser.add_argument(
-        "-min", "--mindate", help="earliest acceptable date (YYYY-MM-DD)", type=str
+        "-min", "--mindate", help="earliest acceptable date (ISO 8601 YMD)", type=str
     )
     argsparser.add_argument(
-        "-max", "--maxdate", help="latest acceptable date (YYYY-MM-DD)", type=str
+        "-max", "--maxdate", help="latest acceptable date (ISO 8601 YMD)", type=str
     )
     argsparser.add_argument("-u", "--URL", help="custom URL download", type=str)
     argsparser.add_argument(

--- a/htmldate/core.py
+++ b/htmldate/core.py
@@ -14,7 +14,7 @@ from collections import Counter
 from copy import deepcopy
 from datetime import datetime
 from functools import lru_cache, partial
-from typing import Match, Optional, Pattern, Tuple, Counter as Counter_Type
+from typing import Match, Optional, Pattern, Tuple, Union, Counter as Counter_Type
 
 from lxml.html import HtmlElement, tostring  # type: ignore
 
@@ -263,11 +263,11 @@ def examine_header(
         one (e.g. last modified, updated time)
     :type original_date: boolean
     :param min_date:
-        Set the earliest acceptable date manually (YYYY-MM-DD format)
-    :type min_date: string
+        Set the earliest acceptable date manually (ISO 8601 YMD format)
+    :type min_date: datetime
     :param max_date:
-        Set the latest acceptable date manually (YYYY-MM-DD format)
-    :type max_date: string
+        Set the latest acceptable date manually (ISO 8601 YMD format)
+    :type max_date: datetime
     :return: Returns a valid date expression as a string, or None
 
     """
@@ -673,6 +673,12 @@ def search_page(
         Look for original date (e.g. publication date) instead of most recent
         one (e.g. last modified, updated time)
     :type original_date: boolean
+    :param min_date:
+        Set the earliest acceptable date manually (ISO 8601 YMD format)
+    :type min_date: datetime
+    :param max_date:
+        Set the latest acceptable date manually (ISO 8601 YMD format)
+    :type max_date: datetime
     :return: Returns a valid date expression as a string, or None
 
     """
@@ -941,8 +947,8 @@ def find_date(
     outputformat: str = "%Y-%m-%d",
     url: Optional[str] = None,
     verbose: bool = False,
-    min_date: Optional[datetime] = None,
-    max_date: Optional[datetime] = None,
+    min_date: Optional[Union[datetime, str]] = None,
+    max_date: Optional[Union[datetime, str]] = None,
     deferred_url_extractor: bool = False,
 ) -> Optional[str]:
     """
@@ -971,11 +977,11 @@ def find_date(
         Set verbosity level for debugging
     :type verbose: boolean
     :param min_date:
-        Set the earliest acceptable date manually (YYYY-MM-DD format)
-    :type min_date: string
+        Set the earliest acceptable date manually (ISO 8601 YMD format)
+    :type min_date: datetime, string
     :param max_date:
-        Set the latest acceptable date manually (YYYY-MM-DD format)
-    :type max_date: string
+        Set the latest acceptable date manually (ISO 8601 YMD format)
+    :type max_date: datetime, string
     :param deferred_url_extractor:
         Use url extractor as backup only to prioritize full expressions,
         e.g. of the type `%Y-%m-%d %H:%M:%S`

--- a/htmldate/extractors.py
+++ b/htmldate/extractors.py
@@ -22,13 +22,6 @@ from dateutil.parser import parse as dateutil_parse
 
 from lxml.html import HtmlElement  # type: ignore
 
-try:
-    datetime.fromisoformat  # type: ignore[attr-defined]
-except AttributeError:  # Python 3.6
-    from backports.datetime_fromisoformat import MonkeyPatch  # type: ignore
-
-    MonkeyPatch.patch_fromisoformat()
-
 # own
 from .settings import CACHE_SIZE
 from .validators import convert_date, date_validator

--- a/htmldate/validators.py
+++ b/htmldate/validators.py
@@ -196,7 +196,7 @@ def check_extracted_reference(
 
 def _get_date(
     date_str: Optional[Union[datetime, str]],
-    default: Optional[datetime]=None,
+    default: Optional[datetime] = None,
 ) -> datetime:
     if date_str is None:
         return default
@@ -205,7 +205,7 @@ def _get_date(
     try:
         return datetime.fromisoformat(date_str)
     except (ValueError, TypeError):
-        LOGGER.warning('Invalid datetime %r. Should be isoformat. Ignoring.', date_str)
+        LOGGER.warning("Invalid datetime %r. Should be isoformat. Ignoring.", date_str)
         return default
 
 

--- a/htmldate/validators.py
+++ b/htmldate/validators.py
@@ -194,23 +194,25 @@ def check_extracted_reference(
     return None
 
 
-def _get_date(date_str: Optional[Union[datetime, str]], default: datetime) -> datetime:
-    if date_str is None:
-        return default
-    if isinstance(date_str, datetime):
-        return date_str
-    try:
-        return datetime.fromisoformat(date_str)  # type: ignore
-    except (ValueError, TypeError):
-        LOGGER.warning("Invalid datetime %r. Should be isoformat. Ignoring.", date_str)
-        return default
+def check_date_input(
+    date_object: Optional[Union[datetime, str]], default: datetime
+) -> datetime:
+    "Check if the input is a usable datetime or ISO date string, return default otherwise"
+    if isinstance(date_object, datetime):
+        return date_object
+    elif isinstance(date_object, str):
+        try:
+            return datetime.fromisoformat(date_object)  # type: ignore
+        except ValueError:
+            LOGGER.warning("invalid datetime string: %s", date_object)
+    return default  # no input or error thrown
 
 
 def get_min_date(min_date: Optional[Union[datetime, str]]) -> datetime:
     """Validates the minimum date and/or defaults to earliest plausible date"""
-    return _get_date(min_date, MIN_DATE)
+    return check_date_input(min_date, MIN_DATE)
 
 
 def get_max_date(max_date: Optional[Union[datetime, str]]) -> datetime:
     """Validates the maximum date and/or defaults to latest plausible date"""
-    return _get_date(max_date, datetime.now())
+    return check_date_input(max_date, datetime.now())

--- a/htmldate/validators.py
+++ b/htmldate/validators.py
@@ -200,7 +200,7 @@ def check_date_input(
     "Check if the input is a usable datetime or ISO date string, return default otherwise"
     if isinstance(date_object, datetime):
         return date_object
-    elif isinstance(date_object, str):
+    if isinstance(date_object, str):
         try:
             return datetime.fromisoformat(date_object)  # type: ignore
         except ValueError:

--- a/htmldate/validators.py
+++ b/htmldate/validators.py
@@ -200,7 +200,7 @@ def _get_date(date_str: Optional[Union[datetime, str]], default: datetime) -> da
     if isinstance(date_str, datetime):
         return date_str
     try:
-        return datetime.fromisoformat(date_str)
+        return datetime.fromisoformat(date_str)  # type: ignore
     except (ValueError, TypeError):
         LOGGER.warning("Invalid datetime %r. Should be isoformat. Ignoring.", date_str)
         return default

--- a/htmldate/validators.py
+++ b/htmldate/validators.py
@@ -194,10 +194,7 @@ def check_extracted_reference(
     return None
 
 
-def _get_date(
-    date_str: Optional[Union[datetime, str]],
-    default: Optional[datetime] = None,
-) -> datetime:
+def _get_date(date_str: Optional[Union[datetime, str]], default: datetime) -> datetime:
     if date_str is None:
         return default
     if isinstance(date_str, datetime):

--- a/htmldate/validators.py
+++ b/htmldate/validators.py
@@ -195,7 +195,8 @@ def check_extracted_reference(
 
 
 def _get_date(
-        date_str: Optional[Union[datetime, str]], default: Optional[datetime]=None,
+    date_str: Optional[Union[datetime, str]],
+    default: Optional[datetime]=None,
 ) -> datetime:
     if date_str is None:
         return default
@@ -204,7 +205,7 @@ def _get_date(
     try:
         return datetime.fromisoformat(date_str)
     except (ValueError, TypeError):
-        LOGGER.warning('Invalid datetime spec %r. Should be isoformat. Ignoring.', date_str)
+        LOGGER.warning('Invalid datetime %r. Should be isoformat. Ignoring.', date_str)
         return default
 
 

--- a/htmldate/validators.py
+++ b/htmldate/validators.py
@@ -194,31 +194,25 @@ def check_extracted_reference(
     return None
 
 
+def _get_date(
+        date_str: Optional[Union[datetime, str]], default: Optional[datetime]=None,
+) -> datetime:
+    if date_str is None:
+        return default
+    if isinstance(date_str, datetime):
+        return date_str
+    try:
+        return datetime.fromisoformat(date_str)
+    except (ValueError, TypeError):
+        LOGGER.warning('Invalid datetime spec %r. Should be isoformat. Ignoring.', date_str)
+        return default
+
+
 def get_min_date(min_date: Optional[Union[datetime, str]]) -> datetime:
     """Validates the minimum date and/or defaults to earliest plausible date"""
-    if min_date is not None and isinstance(min_date, str):
-        try:
-            # internal conversion from Y-M-D format
-            min_date = datetime(
-                int(min_date[:4]), int(min_date[5:7]), int(min_date[8:10])
-            )
-        except ValueError:
-            min_date = MIN_DATE
-    else:
-        min_date = MIN_DATE
-    return min_date
+    return _get_date(min_date, MIN_DATE)
 
 
 def get_max_date(max_date: Optional[Union[datetime, str]]) -> datetime:
     """Validates the maximum date and/or defaults to latest plausible date"""
-    if max_date is not None and isinstance(max_date, str):
-        try:
-            # internal conversion from Y-M-D format
-            max_date = datetime(
-                int(max_date[:4]), int(max_date[5:7]), int(max_date[8:10])
-            )
-        except ValueError:
-            max_date = datetime.now()
-    else:
-        max_date = datetime.now()
-    return max_date
+    return _get_date(max_date, datetime.now())

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -616,6 +616,14 @@ def test_exact_date():
         )
         == "1991-01-02"
     )
+    assert (
+        find_date(
+            '<html><meta><meta property="article:published_time" content="1991-01-02T01:01:00+01:00"></meta><body></body></html>',
+            min_date=datetime.datetime(1990, 1, 1),
+        )
+        == "1991-01-02"
+    )
+    
 
     # wild text in body
     assert (

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -125,13 +125,13 @@ def test_input():
     assert get_min_date(None).date() == datetime.date(1995, 1, 1)
     assert get_min_date("3030-30-50").date() == datetime.date(1995, 1, 1)
     assert get_min_date(datetime.datetime(1990, 1, 1)) == datetime.datetime(1990, 1, 1)
-    assert get_min_date("2020-02-20 13:30:00") == datetime.datetime(2020, 2, 20, 13, 30)
+    assert get_min_date("2020-02-20T13:30:00") == datetime.datetime(2020, 2, 20, 13, 30)
 
     assert get_max_date("2020-02-20").date() == datetime.date(2020, 2, 20)
     assert get_max_date(None).date() == datetime.date.today()
     assert get_max_date("3030-30-50").date() == datetime.date.today()
     assert get_max_date(datetime.datetime(3000, 1, 1)) == datetime.datetime(3000, 1, 1)
-    assert get_max_date("2020-02-20 13:30:00") == datetime.datetime(2020, 2, 20, 13, 30)
+    assert get_max_date("2020-02-20T13:30:00") == datetime.datetime(2020, 2, 20, 13, 30)
 
 
 def test_sanity():
@@ -637,15 +637,15 @@ def test_exact_date():
     )
     assert (
         find_date(
-            '<html><meta><meta property="article:published_time" content="1991-01-02T01:01:00+01:00"></meta><body></body></html>',
-            min_date="1991-01-02 01:02:00",
+            '<html><meta><meta property="article:published_time" content="1991-01-02T01:01:00+00:00"></meta><body></body></html>',
+            min_date="1991-01-02T01:02:00+00:00",
         )
         is None
     )
     assert (
         find_date(
-            '<html><meta><meta property="article:published_time" content="1991-01-02T01:01:00+01:00"></meta><body></body></html>',
-            min_date="1991-01-02 01:00:00",
+            '<html><meta><meta property="article:published_time" content="1991-01-02T01:01:00+00:00"></meta><body></body></html>',
+            min_date="1991-01-02T01:00:00+00:00",
         )
         == "1991-01-02"
     )


### PR DESCRIPTION
* support passing datetimes and including time component, e.g.
  * `find_date(..., min_date=datetime(...))`
  * `find_date(..., max_date="2020-03-14 12:46:58")`
* raise warning on invalid argument while preserving previous behavior/result
* correctly respect typing annotation
* consolidate code