### PR TITLE
fix value error in some cases while parsing date

### DIFF
--- a/htmldate/extractors.py
+++ b/htmldate/extractors.py
@@ -207,8 +207,8 @@ SLASHES_PATTERN = re.compile(
     r"\D([0-3]?[0-9]/[01]?[0-9]/[0129][0-9]|[0-3][0-9]\.[01][0-9]\.[0129][0-9])\D"
 )
 SLASHES_YEAR = re.compile(r"([0-9]{2})$")
-YYYYMM_PATTERN = re.compile(r"\D([12][0-9]{3}[/.-][01][0-9])\D")
-YYYYMM_CATCH = re.compile(rf"({YEAR_RE})[/.-]([01][0-9])")
+YYYYMM_PATTERN = re.compile(r"\D([12][0-9]{3}[/.-](?:1[0-2]|0?[1-9]))\D")
+YYYYMM_CATCH = re.compile(rf"({YEAR_RE})[/.-](1[0-2]|0?[1-9]|)")
 MMYYYY_PATTERN = re.compile(r"\D([01]?[0-9][/.-][12][0-9]{3})\D")
 MMYYYY_YEAR = re.compile(rf"({YEAR_RE})\D?$")
 SIMPLE_PATTERN = re.compile(rf"(?<!w3.org)\D({YEAR_RE})\D")

--- a/tests/cache/mozilla.org.mfsa2024-17.html
+++ b/tests/cache/mozilla.org.mfsa2024-17.html
@@ -1,0 +1,971 @@
+<!doctype html>
+
+<html class="windows no-js" lang="en" dir="ltr" data-country-code="AT" data-latest-firefox="124.0.2" data-esr-versions="115.9.1" data-gtm-container-id="GTM-MW3R8V"  data-stub-attribution-rate="1.0" data-sentry-dsn="https://c3ab8514873549d5b3785ebc7fb83c80@o1069899.ingest.sentry.io/6260331" >
+  <head>
+    <meta charset="utf-8">
+
+    <!--[if !IE]><!-->
+    <script src="https://www.mozilla.org/media/js/site.9537923fdd7f.js"></script>
+
+    
+    <!--<![endif]-->
+
+<!--
+
+
+             _.-~-.
+           7''  Q..\
+        _7         (_
+      _7  _/    _q.  /
+    _7 . ___  /VVvv-'_                                            .
+   7/ / /~- \_\\      '-._     .-'                      /       //
+  ./ ( /-~-/||'=.__  '::. '-~'' {             ___   /  //     ./{
+ V   V-~-~| ||   __''_   ':::.   ''~-~.___.-'' _/  // / {_   /  {  /
+  VV/-~-~-|/ \ .'__'. '.    '::                     _ _ _        ''.
+  / /~~~~||VVV/ /  \ )  \        _ __ ___   ___ ___(_) | | __ _   .::'
+ / (~-~-~\\.-' /    \'   \::::. | '_ ` _ \ / _ \_  / | | |/ _` | :::'
+/..\    /..\__/      '     '::: | | | | | | (_) / /| | | | (_| | ::'
+vVVv    vVVv                 ': |_| |_| |_|\___/___|_|_|_|\__,_| ''
+
+Hi there, nice to meet you!
+
+Interested in having a direct impact on hundreds of millions of users? Join
+Mozilla, and become part of a global community that’s helping to build a
+brighter future for the Web.
+
+Visit https://www.mozilla.org/careers to learn about our current job openings.
+Visit https://www.mozilla.org/contribute for more ways to get involved and
+help support Mozilla.
+-->
+
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    
+
+    
+    <title>Security Vulnerabilities fixed in Firefox for iOS 124 — Mozilla</title>
+    <meta name="description" content="">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Mozilla">
+    <meta property="og:locale" content="en_US">
+    <meta property="og:url" content="https://www.mozilla.org/en-US/security/advisories/mfsa2024-17/">
+    <meta property="og:image" content="https://www.mozilla.org/media/img/mozorg/mozilla-256.4720741d4108.jpg">
+    <meta property="og:title" content="Security Vulnerabilities fixed in Firefox for iOS 124">
+    <meta property="og:description" content="">
+    <meta property="fb:page_id" content="262134952380">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:site" content="@mozilla">
+    <meta name="twitter:domain" content="mozilla.org">
+    <meta name="twitter:app:name:googleplay" content="Firefox">
+    <meta name="twitter:app:id:googleplay" content="org.mozilla.firefox">
+    <meta name="twitter:app:name:iphone" content="Firefox">
+    <meta name="twitter:app:id:iphone" content="989804926">
+    <meta name="twitter:app:name:ipad" content="Firefox">
+    <meta name="twitter:app:id:ipad" content="989804926">
+    <link rel="apple-touch-icon" type="image/png" sizes="180x180" href="https://www.mozilla.org/media/img/favicons/mozilla/apple-touch-icon.8cbe9c835c00.png">
+    <link rel="icon" type="image/png" sizes="196x196" href="https://www.mozilla.org/media/img/favicons/mozilla/favicon-196x196.2af054fea211.png">
+    <link rel="shortcut icon" href="https://www.mozilla.org/media/img/favicons/mozilla/favicon.d25d81d39065.ico">
+    
+
+    <link rel="canonical" href="https://www.mozilla.org/en-US/security/advisories/mfsa2024-17/">
+    <link rel="alternate" hreflang="x-default" href="https://www.mozilla.org/security/advisories/mfsa2024-17/">
+    <link rel="alternate" hreflang="en" href="https://www.mozilla.org/en-US/security/advisories/mfsa2024-17/" title="English">
+        <link rel="alternate" hreflang="en-US" href="https://www.mozilla.org/en-US/security/advisories/mfsa2024-17/" title="English (USA)">
+        
+    
+    
+    <link href="https://mastodon.social/@mozilla" rel="me">
+
+    
+
+    <!--[if lt IE 9]>
+      
+      <script src="https://www.mozilla.org/media/js/ie/libs/html5shiv.a94a0b700fa2.js"></script>
+    <![endif]-->
+
+    <!--[if IE]>
+      
+      
+        <link href="https://www.mozilla.org/media/css/common-old-ie.f4fdca330278.css" rel="stylesheet" type="text/css">
+      
+    <![endif]-->
+
+    <!--[if !IE]><!-->
+    
+    
+  
+  <link href="https://www.mozilla.org/media/css/protocol-mozilla.9dd07c546e17.css" rel="stylesheet" type="text/css">
+
+  <link href="https://www.mozilla.org/media/css/basic-article.ad1a7051385f.css" rel="stylesheet" type="text/css">
+
+
+    
+    
+  <link href="https://www.mozilla.org/media/css/security.a15c7082e6bb.css" rel="stylesheet" type="text/css">
+
+    <!--<![endif]-->
+
+    
+      
+    
+
+    
+    
+      
+
+<!--
+Read more about our custom configuration and use of Google Analytics here:
+https://bugzilla.mozilla.org/show_bug.cgi?id=1122305#c8
+-->
+
+<!-- Google Tag Manager -->
+<!-- Customized for Mozilla.org-->
+<!-- Region Container: NONE -->
+<!-- Rollup Container: System Filtered -->
+<!-- Site Container: NONE -->
+
+
+  <!--[if !IE]><!-->
+    <script src="https://www.mozilla.org/media/js/gtm-snippet.a788d552f536.js"></script>
+  <!--<![endif]-->
+
+  <!--[if IE]>
+    <script src="https://www.mozilla.org/media/js/ie/gtm-snippet.6d675606f676.js"></script>
+  <![endif]-->
+
+<!-- End Google Tag Manager -->
+    
+  </head>
+
+  <body class="html-ltr mzp-t-mozilla " >
+    <div id="strings"
+      data-global-close="Close"
+      data-global-next="Next"
+      data-global-previous="Previous"
+      ></div>
+
+    
+      
+
+
+
+  
+
+
+<div class="c-navigation top-header-navigation mzp-is-sticky">
+  <div class="c-navigation-l-content">
+    <div class="c-navigation-container">
+      <button class="c-navigation-menu-button" type="button" aria-controls="c-navigation-items">Menu</button>
+      <div class="c-navigation-logo">
+        <a href="/en-US/" data-link-text="mozilla home icon" data-link-type="nav">
+          <img class="c-navigation-logo-image" src="https://www.mozilla.org/media/protocol/img/logos/mozilla/logo-word-hor.e20791bb4dd4.svg" alt="Mozilla" width="112" height="32">
+        </a>
+      </div>
+
+      <div class="c-navigation-items" id="c-navigation-items">
+        
+
+
+  <div class="c-navigation-shoulder">
+    
+      
+        
+
+<div id="protocol-nav-download-firefox" class="mzp-c-button-download-container c-button-download-thanks">
+  <a href="/firefox/download/thanks/"
+     class="download-link c-button-download-thanks-link mzp-c-button mzp-t-product mzp-t-secondary mzp-t-md"
+     data-direct-link="https://download.mozilla.org/?product=firefox-stub&amp;os=win&amp;lang=en-US"
+     data-link-type="download"
+     data-download-location="nav">
+    
+      Download Firefox
+    
+  </a>
+
+  
+  
+
+
+  
+
+
+<div class="fx-unsupported-message win" data-nosnippet="true">
+  <p><strong>Firefox is <a href="https://support.mozilla.org/kb/firefox-users-windows-7-8-and-81-moving-extended-support">no longer supported</a> on Windows 8.1 and below.</strong></p>
+  <p>Please download Firefox ESR (Extended Support Release) to use Firefox.</p>
+  <div class="download-platform-list">
+    <p>
+      <a class="mzp-c-button mzp-t-product download-link os_win64 ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=win64&lang=en-US" data-link-type="download" data-download-os="Desktop" data-download-version="win64" data-display-name="Firefox Extended Support Release">
+        Download Firefox ESR 64-bit
+      </a>
+    </p>
+    <p>
+      <a class="mzp-c-button mzp-t-product download-link os_win ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=win&lang=en-US" data-link-type="download" data-download-os="Desktop" data-download-version="win" data-display-name="Firefox Extended Support Release">
+        Download Firefox ESR 32-bit
+      </a>
+    </p>
+
+    <small class="fx-unsupported-message-all-link">
+      <a href="/en-US/firefox/all/#product-desktop-esr">
+        Download a different build
+      </a>
+    </small>
+  </div>
+</div>
+
+<div class="fx-unsupported-message mac" data-nosnippet="true">
+  <p><strong>Firefox is <a href="https://support.mozilla.org/kb/firefox-users-macos-1012-1013-1014-moving-to-extended-support">no longer supported</a> on macOS 10.14 and below.</strong></p>
+  <p>Please download Firefox ESR (Extended Support Release) to use Firefox.</p>
+
+  <div class="download-platform-list">
+    <a class="mzp-c-button mzp-t-product download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=osx&lang=en-US" data-link-type="download" data-download-os="Desktop" data-download-version="osx" data-display-name="Firefox Extended Support Release">
+      Download Firefox ESR
+    </a>
+  </div>
+</div>
+
+  <small class="mzp-c-button-download-privacy-link">
+    <a href="/en-US/privacy/firefox/">
+      Firefox Privacy Notice
+    </a>
+  </small>
+</div>
+      
+      
+      <div class="c-navigation-vpn-cta-container">
+        <a href="/en-US/products/vpn/#pricing" class="mzp-c-button js-fxa-product-referral-link mzp-t-product mzp-t-secondary mzp-t-md" data-referral-id="navigation" data-cta-text="Get Mozilla VPN" data-cta-type="button" data-cta-position="navigation">Get Mozilla VPN</a>
+      </div>
+      
+    
+  </div>
+
+        <div class="c-navigation-menu">
+          <nav class="c-menu mzp-is-basic">
+            <ul class="c-menu-category-list">
+              
+
+
+
+<li class="c-menu-category mzp-has-drop-down mzp-js-expandable">
+  <a class="c-menu-title" href="/en-US/firefox/" aria-haspopup="true" aria-controls="c-menu-panel-firefox">Firefox Browsers</a>
+  <div class="c-menu-panel" id="c-menu-panel-firefox">
+    <div class="c-menu-panel-container">
+      <button class="c-menu-button-close" type="button" aria-controls="c-menu-panel-firefox">Close Firefox Browsers menu</button>
+      <div class="c-menu-panel-content">
+        <ul class="mzp-l-rows-four">
+          <li>
+            <section class="c-menu-item mzp-has-icon">
+              <a class="c-menu-item-link" href="/en-US/firefox/new/" data-link-text="Firefox Desktop Browser" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
+                <img loading="lazy" src="https://www.mozilla.org/media/protocol/img/logos/firefox/browser/logo.eb1324e44442.svg" class="c-menu-item-icon" width="32" height="32" alt="">
+                <h4 class="c-menu-item-title">Firefox for Desktop</h4>
+                <p class="c-menu-item-desc">Get the not-for-profit-backed browser on Windows, Mac or Linux.</p>
+              </a>
+            </section>
+          </li>
+        
+          <li>
+            <section class="c-menu-item mzp-has-icon">
+              <a class="c-menu-item-link" href="/en-US/firefox/browsers/mobile/android/" data-link-text="Firefox for Android" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
+                <img loading="lazy" src="https://www.mozilla.org/media/protocol/img/logos/firefox/browser/logo.eb1324e44442.svg" class="c-menu-item-icon" width="32" height="32" alt="">
+                <h4 class="c-menu-item-title">Firefox for Android</h4>
+                <p class="c-menu-item-desc">Get the customizable mobile browser for Android smartphones.</p>
+              </a>
+            </section>
+          </li>
+          <li>
+            <section class="c-menu-item mzp-has-icon">
+              <a class="c-menu-item-link" href="/en-US/firefox/browsers/mobile/ios/" data-link-text="Firefox for iOS" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
+                <img loading="lazy" src="https://www.mozilla.org/media/protocol/img/logos/firefox/browser/logo.eb1324e44442.svg" class="c-menu-item-icon" width="32" height="32" alt="">
+                <h4 class="c-menu-item-title">Firefox for iOS</h4>
+                <p class="c-menu-item-desc">Get the mobile browser for your iPhone or iPad.</p>
+              </a>
+            </section>
+          </li>
+        
+          <li>
+            <section class="c-menu-item mzp-has-icon">
+              <a class="c-menu-item-link" href="/en-US/firefox/browsers/mobile/focus/" data-link-text="Firefox Focus" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
+                <img loading="lazy" src="https://www.mozilla.org/media/protocol/img/logos/firefox/browser/focus/logo.aac3e33175cb.svg" class="c-menu-item-icon" width="32" height="32" alt="">
+                <h4 class="c-menu-item-title">Firefox Focus</h4>
+                <p class="c-menu-item-desc">Simply private mobile browsing.</p>
+              </a>
+            </section>
+          </li>
+          <li>
+            <section class="c-menu-item mzp-has-icon">
+              <a class="c-menu-item-link" href="/en-US/firefox/privacy/" data-link-text="Privacy Promise" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
+                <img loading="lazy" src="https://www.mozilla.org/media/img/nav/icons/icon-privacy-promise.eee1662acb03.svg" class="c-menu-item-icon" width="32" height="32" alt="">
+                <h4 class="c-menu-item-title">Privacy Promise</h4>
+                <p class="c-menu-item-desc">Learn how Firefox treats your data with respect.</p>
+              </a>
+            </section>
+          </li>
+          <li>
+            <section class="c-menu-item mzp-has-icon">
+              <a class="c-menu-item-link" href="https://blog.mozilla.org/firefox/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=nav&amp;utm_content=firefox" data-link-text="Firefox Blog" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
+                <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="#42435a" d="M21.1 7.5c-.2-.2-.2-.5 0-.7l.5-.5c.8-.8 2.1-.8 2.9 0l1.2 1.2c.8.8.8 2.1 0 2.9l-.5.5c-.2.2-.5.2-.7 0l-3.4-3.4zm2.3 4.5c.2.2.2.5 0 .7L12.7 23.4c-.2.2-.4.3-.6.4l-5.7 2.4c-.3.1-.6 0-.7-.3-.1-.1-.1-.3 0-.4L8.1 20c.1-.2.3-.5.4-.6L19.2 8.6c.2-.2.5-.2.7 0l3.5 3.4zM11.5 22.7l-3.9 1.7 1.7-3.9c0-.1.1-.2.2-.2l2.3 2.3c-.1 0-.2.1-.3.1z"></path></svg>
+                <h4 class="c-menu-item-title">Firefox Blog</h4>
+                <p class="c-menu-item-desc">Read about new Firefox features and ways to stay safe online.</p>
+              </a>
+            </section>
+          </li>
+          <li>
+            <section class="c-menu-item mzp-has-icon">
+              <a class="c-menu-item-link" href="/firefox/124.0.2/releasenotes/" data-link-text="Release Notes" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
+                <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="#42435a" d="M2.7 23.6c0 2.4 2 4.4 4.4 4.4h5.6c1.4 0 2.3.5 3.3 1.5 1-1 2-1.5 3.3-1.5h5.6c2.4 0 4.4-2 4.4-4.4V8.4c0-2.4-2-4.4-4.4-4.4h-5.6C18 4 17 4.2 16 5.2c-1-1-2-1.2-3.3-1.2H7.1C4.6 4 2.7 6 2.7 8.4v15.2zm24 0c0 1-.8 1.7-1.7 1.7h-5.6c-1.3 0-2.3.2-3.3 1.2-1-1-2-1.2-3.3-1.2H7.1c-1 0-1.7-.8-1.7-1.7V8.4c0-1 .8-1.7 1.7-1.7h5.6c1.3 0 2.3.5 3.3 1.5 1-1 2-1.5 3.3-1.5h5.6c1 0 1.7.8 1.7 1.7v15.2zM13.3 10.7H8c-.4 0-.7-.3-.7-.7 0-.4.3-.7.7-.7h5.3c.4 0 .7.3.7.7 0 .4-.3.7-.7.7zm-5.3 4h5.3c.4 0 .7-.3.7-.7s-.3-.7-.7-.7H8c-.4 0-.7.3-.7.7s.3.7.7.7zm5.3 4H8c-.4 0-.7-.3-.7-.7s.3-.7.7-.7h5.3c.4 0 .7.3.7.7s-.3.7-.7.7zm-5.3 4h3.4c.4 0 .7-.3.7-.7s-.3-.7-.7-.7H8c-.4 0-.7.3-.7.7s.3.7.7.7z"></path></svg>
+                <h4 class="c-menu-item-title">Release Notes</h4>
+              
+                <p class="c-menu-item-desc">Get the details on the latest Firefox updates.</p>
+              
+              </a>
+            </section>
+          </li>
+        </ul>
+        <p class="c-menu-category-link"><a href="/en-US/firefox/" data-link-text="View all Firefox Browsers" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">View all Firefox Browsers</a></p>
+      </div>
+    </div><!-- close .c-menu-panel-container -->
+  </div><!-- close .c-menu-panel -->
+</li><!-- close firefox -->
+              
+
+
+
+<li class="c-menu-category mzp-has-drop-down mzp-js-expandable">
+  <a class="c-menu-title" href="/en-US/products/" aria-haspopup="true" aria-controls="c-menu-panel-products">Products</a>
+  <div class="c-menu-panel" id="c-menu-panel-products">
+    <div class="c-menu-panel-container">
+      <button class="c-menu-button-close" type="button" aria-controls="c-menu-panel-products">Close Products menu</button>
+      <div class="c-menu-panel-content">
+        <ul class="mzp-l-rows-four">
+          <li>
+            <section class="c-menu-item mzp-has-icon">
+              
+              <a class="c-menu-item-link" href="https://monitor.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=nav&amp;utm_content=products" data-link-text="Mozilla Monitor" data-link-type="nav" data-link-position="topnav" data-link-group="products">
+                <img loading="lazy" src="https://www.mozilla.org/media/protocol/img/logos/firefox/monitor/logo.d97e5516f9e6.svg" class="c-menu-item-icon" width="32" height="32" alt="">
+                
+                  <h4 class="c-menu-item-title">Mozilla Monitor</h4>
+                
+                <p class="c-menu-item-desc">See if your email has appeared in a company’s data breach.</p>
+              </a>
+            </section>
+          </li>
+          <li>
+            <section class="c-menu-item mzp-has-icon">
+              <a class="c-menu-item-link" href="/en-US/firefox/facebookcontainer/" data-link-text="Facebook Container" data-link-type="nav" data-link-position="topnav" data-link-group="products">
+                <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="#f80073" d="M27 1H5C2.8 1 1 2.8 1 5v22c0 2.2 1.8 4 4 4h22c2.2 0 4-1.8 4-4V5c0-2.2-1.8-4-4-4z"></path><path fill="#fff" d="M26 8.8l-1.4-1.4c-.1-.1-.2-.1-.3 0l-1.4 1.4-.1.1v2.8h-2.3V8.9L19 7.4c-.1-.1-.2-.1-.3 0l-1.4 1.4-.1.1v2.8h-2.3V8.9l-1.4-1.4c-.1-.1-.2-.1-.3 0l-1.4 1.4-.1.1v2.8H9.2V8.9L7.8 7.4c-.1-.1-.2-.1-.3 0L6 8.8l-.1.1v15c0 .1.1.2.2.2H9c.1 0 .2-.1.2-.2v-2.8h2.3V24c0 .1.1.2.2.2h2.8c.1 0 .2-.1.2-.2v-2.8H17V24c0 .1.1.2.2.2H20c.1 0 .2-.1.2-.2v-2.8h2.3V24c0 .1.1.2.2.2h2.8c.1 0 .2-.1.2-.2V9c.4-.1.3-.2.3-.2zm-14.7 11H9.2v-6.6h2.3v6.6h-.2zm5.6 0h-2.1v-6.6h2.3v6.6h-.2zm5.7 0h-2.1v-6.6h2.3v6.6h-.2z"></path></svg>
+                <h4 class="c-menu-item-title">Facebook Container</h4>
+              
+                <p class="c-menu-item-desc">Help prevent Facebook from collecting your data outside their site.</p>
+              
+              </a>
+            </section>
+          </li>
+          <li>
+            <section class="c-menu-item mzp-has-icon">
+              <a class="c-menu-item-link" href="https://getpocket.com/firefox_learnmore/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=nav&amp;utm_content=products" data-link-text="Pocket" data-link-type="nav" data-link-position="topnav" data-link-group="products">
+                <img loading="lazy" src="https://www.mozilla.org/media/protocol/img/logos/pocket/logo.17446bc33a5d.svg" class="c-menu-item-icon" width="32" height="32" alt="">
+                <h4 class="c-menu-item-title">Pocket</h4>
+                <p class="c-menu-item-desc">Save and discover the best stories from across the web.</p>
+              </a>
+            </section>
+          </li>
+          <li>
+            <section class="c-menu-item mzp-has-icon">
+              <a class="c-menu-item-link" href="/en-US/products/vpn/" data-link-text="Mozilla VPN" data-link-type="nav" data-link-position="topnav" data-link-group="products">
+                <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="#42435a" d="M26 10.4c-2.5 0-4.7 1.7-5.4 4h-9.3c-.1-.4-.3-.7-.4-1.1l2.4-2.4c.8.4 1.7.7 2.7.7 3.1 0 5.6-2.5 5.6-5.6S19.1.4 16 .4 10.4 2.9 10.4 6c0 1 .2 1.9.7 2.7l-2.4 2.4c-.8-.5-1.7-.7-2.7-.7C2.9 10.4.4 12.9.4 16s2.5 5.6 5.6 5.6c2.5 0 4.7-1.7 5.4-4h9.3c.1.4.3.7.4 1.1l-2.4 2.4c-.8-.4-1.7-.7-2.7-.7-3.1 0-5.6 2.5-5.6 5.6s2.5 5.6 5.6 5.6 5.6-2.5 5.6-5.6c0-1-.2-1.9-.7-2.7l2.4-2.4c.8.4 1.7.7 2.7.7 3.1 0 5.6-2.5 5.6-5.6s-2.5-5.6-5.6-5.6zM16 3.6c1.3 0 2.4 1.1 2.4 2.4S17.3 8.4 16 8.4 13.6 7.3 13.6 6s1.1-2.4 2.4-2.4zM6 18.4c-1.3 0-2.4-1.1-2.4-2.4s1.1-2.4 2.4-2.4c1.3 0 2.4 1.1 2.4 2.4S7.3 18.4 6 18.4zm10 10c-.5 0-1-.2-1.3-.4-.3-.2-.5-.4-.6-.6-.3-.4-.4-.8-.4-1.3s.2-1 .4-1.3c.2-.3.4-.5.6-.6.4-.3.8-.4 1.3-.4 1.3 0 2.4 1.1 2.4 2.4s-1.1 2.2-2.4 2.2zm10-10c-1.3 0-2.4-1.1-2.4-2.4s1.1-2.4 2.4-2.4 2.4 1.1 2.4 2.4-1.1 2.4-2.4 2.4z"></path></svg>
+                <h4 class="c-menu-item-title">Mozilla VPN</h4>
+                <p class="c-menu-item-desc">Get protection beyond your browser, on all your devices.</p>
+              </a>
+            </section>
+          </li>
+          <li>
+            <section class="c-menu-item mzp-has-icon">
+              <a class="c-menu-item-link" href="/en-US/firefox/privacy/products/" data-link-text="Hubs" data-link-type="nav" data-link-position="topnav" data-link-group="projects">
+                <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="#42435a" d="M27.3 7.6c0-1.5-1.1-2.8-2.6-3L16 3.1 7.2 4.6c-1.5.2-2.6 1.5-2.6 3 0 2.4 0 5.5.2 7 .4 4.5 1.3 7 3.5 9.8 1.9 2.4 4.6 4 7.6 4.4h.4c3-.5 5.7-2 7.6-4.4 2.2-2.8 3-5.3 3.5-9.8-.1-1.6-.1-5.1-.1-7zm-2.9 6.7c-.4 4-1.1 6-2.9 8.4-1.4 1.7-3.3 2.9-5.5 3.3-2.2-.4-4.1-1.6-5.5-3.3-1.8-2.4-2.5-4.4-2.9-8.4-.1-1.1-.1-3.5-.1-6.7 0-.1.1-.2.2-.2L16 6l8.3 1.4c.1 0 .2.1.2.2 0 3.2 0 5.7-.1 6.7zm-13.9-.2c0-.4-.1-1.5-.1-4.3l5.6-.9v14.2c-1.3-.3-2.4-1.1-3.2-2.1-1.4-1.8-2-3.1-2.3-6.9z"></path></svg>
+                <h4 class="c-menu-item-title">Product Promise</h4>
+              
+                <p class="c-menu-item-desc">Learn how each Firefox product protects and respects your data.</p>
+              
+              </a>
+            </section>
+          </li>
+          <li>
+            <section class="c-menu-item mzp-has-icon">
+              <a class="c-menu-item-link" href="https://relay.firefox.com/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=nav&amp;utm_content=products" data-link-text="Firefox Relay" data-link-type="nav" data-link-position="topnav" data-link-group="projects">
+                <img loading="lazy" src="https://www.mozilla.org/media/protocol/img/logos/firefox/relay/logo.683083c53b93.svg" class="c-menu-item-icon" width="32" height="32" alt="">
+                <h4 class="c-menu-item-title">Firefox Relay</h4>
+              
+                <p class="c-menu-item-desc">Sign up for new accounts without handing over your email address.</p>
+              
+              </a>
+            </section>
+          </li>
+          <li>
+            <section class="c-menu-item mzp-has-icon">
+              <a class="c-menu-item-link" href="https://developer.mozilla.org/en-US/plus?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=nav&amp;utm_content=products" data-link-text="MDN Plus" data-link-type="nav" data-link-position="topnav" data-link-group="projects">
+                <img loading="lazy" src="https://www.mozilla.org/media/img/nav/icons/icon-mdn-plus.f54475f980ab.svg" class="c-menu-item-icon" width="32" height="32" alt="">
+                <h4 class="c-menu-item-title">MDN Plus</h4>
+              
+                <p class="c-menu-item-desc">New features and tools for a customized MDN experience</p>
+              
+              </a>
+            </section>
+          </li>
+        </ul>
+        <p class="c-menu-category-link"><a href="/en-US/products/" data-link-text="View all Products" data-link-type="nav" data-link-position="topnav" data-link-group="products">View all Products</a></p>
+      </div>
+    </div><!-- close .c-menu-panel-container -->
+  </div><!-- close .c-menu-panel -->
+</li><!-- close products -->
+              
+
+
+
+<li class="c-menu-category mzp-has-drop-down mzp-js-expandable">
+  <a class="c-menu-title" href="/en-US/about/" aria-haspopup="true" aria-controls="c-menu-panel-about">Who We Are</a>
+  <div class="c-menu-panel" id="c-menu-panel-about">
+    <div class="c-menu-panel-container">
+      <button class="c-menu-button-close" type="button" aria-controls="c-menu-panel-about">Close Who We Are menu</button>
+      <div class="c-menu-panel-content">
+        <ul class="mzp-l-rows-four">
+          <li>
+            <section class="c-menu-item mzp-has-icon">
+              <a class="c-menu-item-link" href="/en-US/about/manifesto/" data-link-text="Mozilla Manifesto" data-link-type="nav" data-link-position="topnav" data-link-group="who-we-are">
+                <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="#42435a" d="M9.5 28.6h13.1c2.6 0 4.6-2.1 4.6-4.6V8.1c0-2.6-2.1-4.6-4.6-4.6H9.5c-2.6 0-4.6 2.1-4.6 4.6V24c-.1 2.5 2 4.6 4.6 4.6zM7.6 8.1c0-1 .8-1.8 1.8-1.8h13.1c1 0 1.8.8 1.8 1.8V24c0 1-.8 1.8-1.8 1.8h-13c-1 0-1.8-.8-1.8-1.8V8.1zm12.6 2.3h-8.4c-.4 0-.7-.3-.7-.7 0-.4.3-.7.7-.7h8.4c.4 0 .7.3.7.7 0 .4-.3.7-.7.7zm-8.4 4.2h8.4c.4 0 .7-.3.7-.7s-.3-.7-.7-.7h-8.4c-.4 0-.7.3-.7.7s.3.7.7.7zm8.4 4.2h-8.4c-.4 0-.7-.3-.7-.7s.3-.7.7-.7h8.4c.4 0 .7.3.7.7s-.3.7-.7.7zM11.8 23h3.6c.4 0 .7-.3.7-.7s-.3-.7-.7-.7h-3.6c-.4 0-.7.3-.7.7s.3.7.7.7z"></path></svg>
+                <h4 class="c-menu-item-title">Mozilla Manifesto</h4>
+              
+                <p class="c-menu-item-desc">Learn about the values and principles that guide our mission.</p>
+              
+              </a>
+            </section>
+          </li>
+          <li>
+            <section class="c-menu-item mzp-has-icon">
+              <a class="c-menu-item-link" href="https://foundation.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=nav&amp;utm_content=who-we-are" data-link-text="Mozilla Foundation" data-link-type="nav" data-link-position="topnav" data-link-group="who-we-are">
+                <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="#42435a" d="M16 9.3V4H2.7v24h26.7V9.3H16zm-8 16H5.3v-2.7H8v2.7zM8 20H5.3v-2.7H8V20zm0-5.3H5.3V12H8v2.7zm0-5.4H5.3V6.7H8v2.6zm5.3 16h-2.7v-2.7h2.7v2.7zm0-5.3h-2.7v-2.7h2.7V20zm0-5.3h-2.7V12h2.7v2.7zm0-5.4h-2.7V6.7h2.7v2.6zm13.4 16H16v-2.7h2.7V20H16v-2.7h2.7v-2.7H16V12h10.7v13.3zM24 14.7h-2.7v2.7H24v-2.7zm0 5.3h-2.7v2.7H24V20z"></path></svg>
+                <h4 class="c-menu-item-title">Mozilla Foundation</h4>
+                <p class="c-menu-item-desc">Meet the not-for-profit behind Firefox that stands for a better web.</p>
+              </a>
+            </section>
+          </li>
+          <li>
+            <section class="c-menu-item mzp-has-icon">
+              <a class="c-menu-item-link" href="/en-US/contribute/" data-link-text="Get Involved" data-link-type="nav" data-link-position="topnav" data-link-group="who-we-are">
+                <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="#42435a" d="M12 22.7l4-3.9c-.5-.1-.9-.1-1.3-.1C11.1 18.7 4 20.5 4 24v2.7h12l-4-4zm2.7-6.7c2.9 0 5.3-2.4 5.3-5.3s-2.4-5.3-5.3-5.3-5.3 2.4-5.3 5.3c-.1 2.9 2.3 5.3 5.3 5.3z"></path><path fill="#42435a" d="M20.6 27.3L16 22.7l1.9-1.9 2.8 2.8 6.8-6.9 1.9 1.9-8.8 8.7z"></path></svg>
+                <h4 class="c-menu-item-title">Get involved</h4>
+                <p class="c-menu-item-desc">Join the fight for a healthy internet.</p>
+              </a>
+            </section>
+          </li>
+          <li>
+            <section class="c-menu-item mzp-has-icon">
+              <a class="c-menu-item-link" href="/en-US/about/leadership/" data-link-text="Leadership" data-link-type="nav" data-link-position="topnav" data-link-group="who-we-are">
+                <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="#42435a" d="M22.7 13.9V2.7H9.3v11.2c0 .5.2.9.7 1.1l5.6 3.3-1.3 3.1-4.5.4 3.5 3-1.1 4.4L16 27l3.9 2.4-1-4.4 3.5-3-4.5-.4-1.3-3.1 5.6-3.3c.2-.4.5-.8.5-1.3zm-5.4 2.4l-1.3.8-1.3-.8V4h2.7v12.3z"></path></svg>
+                <h4 class="c-menu-item-title">Leadership</h4>
+              
+                <p class="c-menu-item-desc">Meet the team that’s building technology for a better internet.</p>
+              
+              </a>
+            </section>
+          </li>
+          <li>
+            <section class="c-menu-item mzp-has-icon">
+              <a class="c-menu-item-link" href="/en-US/careers/" data-link-text="Careers" data-link-type="nav" data-link-position="topnav" data-link-group="who-we-are">
+                <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32"><path fill="#42435a" d="M13.3 21.3V20H4v5.3C4 26.8 5.2 28 6.7 28h18.7c1.5 0 2.7-1.2 2.7-2.7V20h-9.3v1.3h-5.5zm13.4-12h-5.3V6.7L18.7 4h-5.3l-2.7 2.7v2.7H5.3c-1.5 0-2.7 1.2-2.7 2.7v4c0 1.5 1.2 2.7 2.7 2.7h8V16h5.3v2.7h8c1.5 0 2.7-1.2 2.7-2.7v-4c0-1.5-1.2-2.7-2.6-2.7zm-8 0h-5.3V6.7h5.3v2.6z"></path></svg>
+                <h4 class="c-menu-item-title">Careers</h4>
+                <p class="c-menu-item-desc">Work for a mission-driven organization that makes people-first products.</p>
+              </a>
+            </section>
+          </li>
+          <li>
+            <section class="c-menu-item mzp-has-icon">
+              <a class="c-menu-item-link" href="https://blog.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=nav&amp;utm_content=who-we-are" data-link-text="Mozilla Blog" data-link-type="nav" data-link-position="topnav" data-link-group="who-we-are">
+                <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="#42435a" d="M21.1 7.5c-.2-.2-.2-.5 0-.7l.5-.5c.8-.8 2.1-.8 2.9 0l1.2 1.2c.8.8.8 2.1 0 2.9l-.5.5c-.2.2-.5.2-.7 0l-3.4-3.4zm2.3 4.5c.2.2.2.5 0 .7L12.7 23.4c-.2.2-.4.3-.6.4l-5.7 2.4c-.3.1-.6 0-.7-.3-.1-.1-.1-.3 0-.4L8.1 20c.1-.2.3-.5.4-.6L19.2 8.6c.2-.2.5-.2.7 0l3.5 3.4zM11.5 22.7l-3.9 1.7 1.7-3.9c0-.1.1-.2.2-.2l2.3 2.3c-.1 0-.2.1-.3.1z"></path></svg>
+                <h4 class="c-menu-item-title">Mozilla Blog</h4>
+              
+                <p class="c-menu-item-desc">Learn about Mozilla and the issues that matter to us.</p>
+              
+              </a>
+            </section>
+          </li>
+
+        </ul>
+        <p class="c-menu-category-link">
+          <a href="/en-US/about/" data-link-text="More About Mozilla" data-link-type="nav" data-link-position="topnav" data-link-group="who-we-are">More About Mozilla</a>
+        </p>
+      </div>
+    </div><!-- close .c-menu-panel-container -->
+  </div><!-- close .c-menu-panel -->
+</li><!-- close who we are -->
+              
+
+
+
+
+  
+
+
+<li class="c-menu-category mzp-has-drop-down mzp-js-expandable">
+  <a class="c-menu-title" href="https://future.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=nav&amp;utm_content=innovation" aria-haspopup="true" aria-controls="c-menu-panel-innovation">Innovation</a>
+  <div class="c-menu-panel" id="c-menu-panel-innovation">
+    <div class="c-menu-panel-container">
+      <button class="c-menu-button-close" type="button" aria-controls="c-menu-panel-innovation">Close Innovation menu</button>
+      <div class="c-menu-panel-content">
+        <ul class="mzp-l-rows-three">
+          <li>
+            <section class="c-menu-item mzp-has-icon">
+              <a class="c-menu-item-link" href="/en-US/firefox/developer/" data-link-text="Firefox Developer Edition" data-link-type="nav" data-link-position="topnav" data-link-group="innovation">
+                <img loading="lazy" src="https://www.mozilla.org/media/protocol/img/logos/firefox/browser/developer/logo.41d42822c8fb.svg" class="c-menu-item-icon" width="32" height="32" alt="">
+                <h4 class="c-menu-item-title">Firefox Developer Edition</h4>
+                <p class="c-menu-item-desc">Get the Firefox browser built just for developers.</p>
+              </a>
+            </section>
+          </li>
+          <li>
+            <section class="c-menu-item mzp-has-icon">
+              <a class="c-menu-item-link" href="https://developer.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=nav&amp;utm_content=innovation" data-link-text="MDN Web Docs" data-link-type="nav" data-link-position="topnav" data-link-group="innovation">
+                <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="#42435a" d="M4 26.7c0 .7.6 1.3 1.3 1.3s1.3-.6 1.3-1.3V5.3C6.7 4.6 6.1 4 5.3 4S4 4.6 4 5.3v21.4zm10.7 0c0 .7.6 1.3 1.3 1.3.7 0 1.3-.6 1.3-1.3V8c0-.7-.6-1.3-1.3-1.3-.7 0-1.3.6-1.3 1.3v18.7zm-5.4 0c0 .7.6 1.3 1.3 1.3.7 0 1.3-.6 1.3-1.3V9.3c.1-.7-.5-1.3-1.2-1.3-.8 0-1.4.6-1.4 1.3v17.4zM26.7 28c-.6 0-1.1-.4-1.3-.9l-6-18.7c-.2-.7.2-1.4.9-1.6s1.4.1 1.7.8l6 18.7c.2.7-.2 1.5-.9 1.7h-.4z"></path></svg>
+                <h4 class="c-menu-item-title">MDN Web Docs</h4>
+                <p class="c-menu-item-desc">Check out the home for web developer resources.</p>
+              </a>
+            </section>
+          </li>
+          <li>
+            <section class="c-menu-item mzp-has-icon">
+              <a class="c-menu-item-link" href="https://commonvoice.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=nav&amp;utm_content=innovation" data-link-text="Common Voice" data-link-type="nav" data-link-position="topnav" data-link-group="innovation">
+                <img loading="lazy" class="c-menu-item-icon" src="https://www.mozilla.org/media/img/nav/icons/icon-common-voice.127fa3f5dcb0.svg" alt="">
+                <h4 class="c-menu-item-title">Common Voice</h4>
+                <p class="c-menu-item-desc">Donate your voice so the future of the web can hear everyone.</p>
+              </a>
+            </section>
+          </li>
+        
+          <li>
+            <section class="c-menu-item mzp-has-icon">
+              <a class="c-menu-item-link" href="https://future.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=nav&amp;utm_content=innovation" data-link-text="Mozilla Innovation Projects" data-link-type="nav" data-link-position="topnav" data-link-group="innovation">
+                <img loading="lazy" class="c-menu-item-icon" src="https://www.mozilla.org/media/img/nav/icons/icon-innovation-projects.11f189479119.svg" alt="">
+                <h4 class="c-menu-item-title">Mozilla Innovation Projects</h4>
+                <p class="c-menu-item-desc">Discover ways to bring bright ideas to life.</p>
+              </a>
+            </section>
+          </li>
+        
+        </ul>
+      </div>
+    </div><!-- close .c-menu-panel-container -->
+  </div><!-- close .c-menu-panel -->
+</li><!-- close innovation -->
+            </ul>
+          </nav>
+        </div><!-- close .c-navigation-menu -->
+      </div><!-- close .c-navigation-items -->
+    </div><!-- close .c-navigation-container -->
+  </div><!-- close .c-navigation-l-content -->
+</div><!-- close .c-navigation -->
+    
+
+    
+
+    <div id="outer-wrapper">
+      
+  
+  <div id="main-content" class="mzp-l-content mzp-has-sidebar mzp-l-sidebar-left">
+    
+      <aside class="mzp-l-sidebar">
+        
+  <nav class="mzp-c-sidemenu">
+    <section class="mzp-c-sidemenu-summary mzp-js-toggle" aria-controls="sidebar-menu">
+      <h3 class="mzp-c-sidemenu-label">Menu</h3>
+      <ul>
+        <li>Mozilla Security</li>
+        
+          
+            
+          
+            
+          
+            
+          
+            
+          
+            
+          
+            
+          
+        
+          
+            
+          
+            
+          
+            
+          
+        
+          
+            
+          
+            
+          
+            
+          
+            
+          
+        
+      </ul>
+    </section>
+    <section class="mzp-c-sidemenu-main">
+      
+
+        <h4 class="mzp-c-sidemenu-title ">
+          <a href="/en-US/security/">Mozilla Security</a>
+        </h4>
+
+        <ul>
+        
+          
+        
+          
+          <li >
+            <a href="/en-US/security/advisories/">Advisories</a>
+          </li>
+          
+        
+          
+          <li >
+            <a href="/en-US/security/known-vulnerabilities/">Known Vulnerabilities</a>
+          </li>
+          
+        
+          
+          <li >
+            <a href="https://blog.mozilla.com/security/">Mozilla Security Blog</a>
+          </li>
+          
+        
+          
+          <li >
+            <a href="/en-US/security/bug-bounty/">Security Bug Bounty</a>
+          </li>
+          
+        
+          
+          <li >
+            <a href="/en-US/security/third-party-software-injection/">Third-party Injection Policy</a>
+          </li>
+          
+        
+        </ul>
+      
+
+        <h4 class="mzp-c-sidemenu-title ">
+          <a href="/en-US/security/client-bug-bounty/">Client Bug Bounty</a>
+        </h4>
+
+        <ul>
+        
+          
+        
+          
+          <li >
+            <a href="/en-US/security/bug-bounty/faq/">Frequently Asked Questions</a>
+          </li>
+          
+        
+          
+          <li >
+            <a href="/en-US/security/bug-bounty/hall-of-fame/">Hall of Fame</a>
+          </li>
+          
+        
+        </ul>
+      
+
+        <h4 class="mzp-c-sidemenu-title ">
+          <a href="/en-US/security/web-bug-bounty/">Web Bug Bounty</a>
+        </h4>
+
+        <ul>
+        
+          
+        
+          
+          <li >
+            <a href="/en-US/security/bug-bounty/web-eligible-sites/">Eligible Websites</a>
+          </li>
+          
+        
+          
+          <li >
+            <a href="/en-US/security/bug-bounty/faq-webapp/">Frequently Asked Questions</a>
+          </li>
+          
+        
+          
+          <li >
+            <a href="/en-US/security/bug-bounty/web-hall-of-fame/">Hall of Fame</a>
+          </li>
+          
+        
+        </ul>
+      
+    </section>
+  </nav>
+
+        
+        
+      </aside>
+    
+
+    <main class="mzp-l-main">
+      <article class="mzp-c-article">
+        
+  <div class="advisory">
+    <header>
+      <h1 class="mzp-c-article-title">Mozilla Foundation Security Advisory 2024-17</h1>
+    </header>
+
+    <h2>Security Vulnerabilities fixed in Firefox for iOS 124</h2>
+
+    <dl class="summary">
+      
+        <dt>Announced</dt>
+        <dd>April  2, 2024</dd>
+      
+      
+      
+      
+        <dt>Impact</dt>
+        <dd><span class="level moderate">moderate</span></dd>
+      
+      <dt>Products</dt>
+      <dd>Firefox for iOS</dd>
+      <dt>Fixed in</dt>
+      <dd>
+        <ul>
+          
+            <li>Firefox for iOS 124</li>
+          
+        </ul>
+      </dd>
+      
+    </dl>
+
+    
+
+<section class="cve">
+  <h4 id="CVE-2024-31393" class="level-heading">
+    <a href="#CVE-2024-31393"><span class="anchor">#</span>CVE-2024-31393: Javascript URLs would load when dragged to address bar</a>
+  </h4>
+  <dl class="summary">
+    <dt>Reporter</dt>
+    <dd>Muneaki Nishimura</dd>
+    <dt>Impact</dt>
+    <dd><span class="level moderate">moderate</span></dd>
+  </dl>
+  <h5>Description</h5>
+  <p>Dragging Javascript URLs to the address bar could cause them to be loaded, bypassing restrictions and security protections</p>
+  
+    <h5>References</h5>
+    <ul>
+      <li><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1879739">Bug 1879739</a></li>
+    </ul>
+  
+</section>
+
+
+
+<section class="cve">
+  <h4 id="CVE-2024-31392" class="level-heading">
+    <a href="#CVE-2024-31392"><span class="anchor">#</span>CVE-2024-31392: Firefox on iOS would show pages with mixed content secure</a>
+  </h4>
+  <dl class="summary">
+    <dt>Reporter</dt>
+    <dd>Chaykin Artem</dd>
+    <dt>Impact</dt>
+    <dd><span class="level low">low</span></dd>
+  </dl>
+  <h5>Description</h5>
+  <p>If an insecure element was added to a page after a delay, Firefox would not replace the secure icon with a mixed content security status</p>
+  
+    <h5>References</h5>
+    <ul>
+      <li><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1875925">Bug 1875925</a></li>
+    </ul>
+  
+</section>
+
+  </div>
+
+      </article>
+    </main>
+  </div>
+
+  
+
+
+      
+  
+
+
+
+<footer class="mzp-c-footer " id="colophon">
+  <div class="mzp-l-content">
+    <nav class="mzp-c-footer-primary">
+      <div class="mzp-c-footer-primary-logo">
+        <a href="/en-US/" data-link-type="footer" data-link-text="Mozilla">Mozilla</a>
+      </div>
+      <div class="mzp-c-footer-sections">
+        <section class="mzp-c-footer-section">
+          <h5 class="mzp-c-footer-heading">
+            Company
+          </h5>
+          <ul class="mzp-c-footer-list">
+            <li><a href="/en-US/about/manifesto/" data-link-type="footer" data-link-text="Mozilla Manifesto">Mozilla Manifesto</a></li>
+            <li><a href="https://blog.mozilla.org/press/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=footer&utm_content=company" data-link-type="footer" data-link-text="Press Center">Press Center</a></li>
+          
+            <li><a href="https://blog.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=footer&utm_content=company" data-link-type="footer" data-link-text="Corporate Blog">Corporate Blog</a></li>
+          
+            <li><a href="/en-US/careers/" data-link-type="footer" data-link-text="Careers">Careers</a></li>
+            <li><a href="/en-US/contact/" data-link-type="footer" data-link-text="Contact">Contact</a></li>
+            <li><a href="https://foundation.mozilla.org/?form=donate&amp;c_id=7014x000000eQOH&amp;utm_source=mozilla.org&amp;utm_medium=referral&amp;utm_campaign=moco&amp;utm_content=footer" data-link-type="footer" data-link-text="Donate">Donate</a></li>
+          
+          </ul>
+        </section>
+
+        <section class="mzp-c-footer-section">
+          <h5 class="mzp-c-footer-heading">
+            Resources
+          </h5>
+          <ul class="mzp-c-footer-list">
+            <li><a href="/en-US/privacy/" data-link-type="footer" data-link-text="Privacy Hub">Privacy Hub</a></li>
+          
+            <li><a href="/en-US/firefox/browsers/compare/" data-link-type="footer" data-link-text="Browser Comparison">Browser Comparison</a></li>
+          
+            <li><a href="https://mozilla.design/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=footer&utm_content=resources" data-link-type="footer" data-link-text="Brand Standards">Brand Standards</a></li>
+          </ul>
+        </section>
+
+        <section class="mzp-c-footer-section">
+          <h5 class="mzp-c-footer-heading">
+            Support
+          </h5>
+          <ul class="mzp-c-footer-list">
+            <li><a href="https://support.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=footer&utm_content=support" data-link-type="footer" data-link-text="Product Help">Product Help</a></li>
+            <li><a href="https://bugzilla.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=footer&utm_content=support" data-link-type="footer" data-link-text="File a Bug">File a Bug</a></li>
+            <li><a href="https://pontoon.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=footer&utm_content=support" data-link-type="footer" data-link-text="Localise Mozilla">Localize Mozilla</a></li>
+          </ul>
+        </section>
+
+        <section class="mzp-c-footer-section">
+          <h5 class="mzp-c-footer-heading">
+            Developers
+          </h5>
+          <ul class="mzp-c-footer-list">
+            <li><a href="/en-US/firefox/developer/" data-link-type="footer" data-link-text="Firefox Developer Edition">Developer Edition</a></li>
+            <li><a href="/en-US/firefox/channel/desktop/#beta" data-link-type="footer" data-link-text="Firefox Beta">Beta</a></li>
+            <li><a href="/en-US/firefox/channel/android/#beta" data-link-type="footer" data-link-text="Firefox Beta for Android">Beta for Android</a></li>
+            <li><a href="/en-US/firefox/channel/desktop/#nightly" data-link-type="footer" data-link-text="Firefox Nightly">Nightly</a></li>
+            <li><a href="/en-US/firefox/channel/android/#nightly" data-link-type="footer" data-link-text="Firefox Nightly for Android">Nightly for Android</a></li>
+            <li><a href="/en-US/firefox/enterprise/" data-link-type="footer" data-link-text="Firefox for Enterprise">Enterprise</a></li>
+            <li><a href="https://firefox-source-docs.mozilla.org/devtools-user/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=footer&utm_content=developers" rel="external" data-link-type="footer" data-link-text="Tools">Tools</a></li>
+          </ul>
+        </section>
+
+        <section class="mzp-c-footer-section">
+          <h5 class="mzp-c-footer-heading-social">Follow @Mozilla</h5>
+          <ul class="mzp-c-footer-links-social">
+            <li><a class="twitter" href="https://twitter.com/mozilla" data-link-type="footer" data-link-text="Twitter (@mozilla)">X (formerly Twitter)<span> (@mozilla)</span></a></li>
+            <li><a class="mastodon" href="https://mozilla.social/@Mozilla" rel="me" data-link-type="footer" data-link-text="Mastodon (@mozilla)">Mastodon<span> (@mozilla)</span></a></li>
+            <li><a class="instagram" href="https://www.instagram.com/mozilla/" data-link-type="footer" data-link-text="Instagram (@mozilla)">Instagram<span> (@mozilla)</span></a></li>
+            <li><a class="linkedin" href="https://www.linkedin.com/company/mozilla-corporation/" data-link-type="footer" data-link-text="LinkedIn (@mozilla)">LinkedIn<span> (@mozilla)</span></a></li>
+            <li><a class="tiktok" href="https://www.tiktok.com/@mozilla" data-link-type="footer" data-link-text="TikTok (@mozilla)">TikTok<span> (@mozilla)</span></a></li>
+            <li><a class="spotify" href="https://open.spotify.com/show/0vT7LJMeVDxyQ2ZamHKu08?si=_uDRD6bRR_6M5YZyISGXgA" data-link-type="footer" data-link-text="Spotify (@mozilla)">Spotify<span> (@mozilla)</span></a></li>
+          </ul>
+
+          <h5 class="mzp-c-footer-heading-social">Follow @Firefox</h5>
+          <ul class="mzp-c-footer-links-social">
+            <li><a class="twitter" href="https://twitter.com/firefox" data-link-type="footer" data-link-text="Twitter (@firefox)">X (formerly Twitter)<span> (@firefox)</span></a></li>
+            <li><a class="instagram" href="https://www.instagram.com/firefox/" data-link-type="footer" data-link-text="Instagram (@firefox)">Instagram<span> (@firefox)</span></a></li>
+            <li><a class="youtube" href="https://www.youtube.com/user/firefoxchannel" data-link-type="footer" data-link-text="YouTube (@firefoxchannel)">YouTube<span> (@firefoxchannel)</span></a></li>
+          </ul>
+        </section>
+      </div>
+    </nav>
+    <nav class="mzp-c-footer-secondary">
+      <div class="mzp-c-footer-language">
+       
+
+
+      </div>
+      <div class="mzp-c-footer-legal">
+        <ul class="mzp-c-footer-terms">
+          <li><a href="/en-US/privacy/websites/" data-link-type="footer" data-link-text="Privacy">Website Privacy Notice</a></li>
+          <li><a href="/en-US/privacy/websites/#user-choices" data-link-type="footer" data-link-text="Cookies">Cookies</a></li>
+          <li><a href="/en-US/about/legal/" data-link-type="footer" data-link-text="Legal">Legal</a></li>
+          <li><a href="/en-US/about/governance/policies/participation/" data-link-type="footer" data-link-text="Community Participation Guidelines">Community Participation Guidelines</a></li>
+          
+            <li><a href="/en-US/about/this-site/" data-link-type="footer" data-link-text="About this site">About this site</a></li>
+          
+        </ul>
+        <p class="mzp-c-footer-license" rel="license">
+          
+          
+          Visit <a href="/en-US/" data-link-text="Mozilla Corporation">Mozilla Corporation’s</a> not-for-profit parent, the <a href="https://foundation.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=footer" rel="external noopener" data-link-text="Mozilla Foundation">Mozilla Foundation</a>.<br>
+          Portions of this content are ©1998–2024 by individual mozilla.org contributors. Content available under a <a rel="license" href="/en-US/foundation/licensing/website-content/">Creative Commons license</a>.
+        </p>
+      </div>
+    </nav>
+  </div>
+</footer>
+
+
+      
+      
+    </div>
+
+    
+    
+      
+        <!--[if !IE]><!-->
+          <script src="https://www.mozilla.org/media/js/sentry.abb6f71aa99b.js"></script>
+        <!--<![endif]-->
+      
+    
+
+    
+  
+      <!--[if !IE]><!-->
+        <script src="https://www.mozilla.org/media/js/lib.f7cc5ac1f5fe.js"></script>
+        <script src="https://www.mozilla.org/media/js/ui.cc2c33643e11.js"></script>
+        <script src="https://www.mozilla.org/media/js/fxa.5a91a2134cef.js"></script>
+        <script src="https://www.mozilla.org/media/js/data.e7de38424803.js"></script>
+      <!--<![endif]-->
+    
+  <!--[if !IE]><!-->
+    <script src="https://www.mozilla.org/media/js/basic-article.56d595614f26.js"></script>
+    <script src="https://www.mozilla.org/media/js/newsletter.b5a0c5f89a86.js"></script>
+  <!--<![endif]-->
+
+
+    
+    
+      
+        <!--[if !IE]><!-->
+          <script src="https://www.mozilla.org/media/js/stub-attribution.ad42212f888d.js"></script>
+        <!--<![endif]-->
+
+        <!--[if gte IE 8]>
+          <script src="https://www.mozilla.org/media/js/stub-attribution-ie.b2310d9f7381.js"></script>
+        <![endif]-->
+      
+    
+
+    <!--[if !IE]><!-->
+    
+      
+    
+
+    
+
+    
+    <!--<![endif]-->
+  </body>
+</html>

--- a/tests/realworld_tests.py
+++ b/tests/realworld_tests.py
@@ -113,6 +113,7 @@ MOCK_PAGES = {
     "https://www.hertie-school.org/en/debate/detail/content/whats-on-the-cards-for-von-der-leyen/": "hertie-school.org.leyen.html",
     "https://www.adac.de/rund-ums-fahrzeug/tests/kindersicherheit/kindersitztest-2018/": "adac.de.kindersitztest.html",
     "http://web.archive.org/web/20210916140120/https://www.kath.ch/die-insel-der-klosterzoeglinge/": "archive.org.kath.ch.html",
+    "https://www.mozilla.org/en-US/security/advisories/mfsa2024-17/": "mozilla.org.mfsa2024-17.html",
 }
 
 MEDIACLOUD_PAGES = {"pagename": "thing.html"}
@@ -647,6 +648,15 @@ def test_approximate_date():
         find_date(load_mock_page("http://www.hundeverein-kreisunna.de/termine.html"))
         == "2017-03-29"
     )  # probably newer
+
+    assert (
+        find_date(
+            load_mock_page(
+                "https://www.mozilla.org/en-US/security/advisories/mfsa2024-17/"
+            )
+        )
+        == "1998-01-01"
+    )
 
 
 def test_search_html():


### PR DESCRIPTION
While parsing specific URLs like: `https://www.mozilla.org/en-US/security/advisories/mfsa2024-17/` 

In this way:

```
from htmldate import find_date
find_date("https://www.mozilla.org/en-US/security/advisories/mfsa2024-17/")
```

The current regex will extract 2024-17 as a date and while parsing it inside [search_page](https://github.com/adbar/htmldate/blob/b5b95dac1deefb5ee062ca89a4a5ba45bf20b75a/htmldate/core.py#L724
)


It throws: `ValueError: month must be in 1..12`


This PR mitigates this, while remaining backwards compatible with all other test cases.

Right now for the test URL it only returns the fallback to the first year of the copyright mention.
