### PR TITLE
Fix documentation wording issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Your support will help ensure the sustainability and growth of the project.
 There are many ways to contribute:
 
   * Sponsor the project: Show your appreciation [on GitHub](https://github.com/sponsors/adbar) or [ko-fi.com](https://ko-fi.com/adbarbaresi)
-  * Find bugs and submit bug reports: Help making Htmldate an even more robust tool
+  * Find bugs and submit bug reports: Help make Htmldate an even more robust tool
   * Write code: Fix bugs or add new features by writing [pull requests](https://docs.github.com/en/pull-requests) with a list of what you have done
 
 A special thanks to the [contributors](https://github.com/adbar/htmldate/graphs/contributors) who have played a part in Htmldate.

--- a/docs/evaluation.rst
+++ b/docs/evaluation.rst
@@ -15,7 +15,7 @@ Alternatives
 There are comparable software solutions in Python, the following date extraction packages are open-source and work out-of-the-box:
 
 - `articleDateExtractor <https://github.com/Webhose/article-date-extractor>`_ detects, extracts and normalizes the publication date of an online article or blog post,
-- `date_guesser <https://github.com/mitmedialab/date_guesser>`_ extracts publication dates from a web pages along with an accuracy measure (not used here),
+- `date_guesser <https://github.com/mitmedialab/date_guesser>`_ extracts publication dates from web pages along with an accuracy measure (not used here),
 - `goose3 <https://github.com/goose3/goose3>`_ can extract information for embedded content,
 - `htmldate <https://github.com/adbar/htmldate>`_ is the software package described here, it is designed to extract original and updated publication dates of web pages,
 - `newspaper4k <https://github.com/AndyTheFactory/newspaper4k>`_ (the maintained successor of newspaper3k) is mostly geared towards newspaper texts,

--- a/docs/joss-article/paper.md
+++ b/docs/joss-article/paper.md
@@ -41,7 +41,7 @@ Large "offline" web text collections are now standard among the research communi
 # Functionality
 
 
-``htmldate`` finds original and updated publication dates of web pages using heuristics on HTML code and linguistic patterns. It operates both within Python and from the command-line. URLs, HTML files, or HTML trees are given as input, and the library outputs a date string in the desired format or ``None`` as the output is thouroughly verified in terms of plausibility and adequateness.
+``htmldate`` finds original and updated publication dates of web pages using heuristics on HTML code and linguistic patterns. It operates both within Python and from the command-line. URLs, HTML files, or HTML trees are given as input, and the library outputs a date string in the desired format or ``None`` as the output is thoroughly verified in terms of plausibility and adequateness.
 
 The package features a combination of tree traversal and text-based extraction, and the following methods are used to date HTML documents:
 
@@ -67,7 +67,7 @@ Diverse extraction and scraping techniques are routinely used on web document co
 There are comparable software solutions in Python. The following date extraction packages are open-source and work out-of-the-box:
 
 - ``articleDateExtractor`` detects, extracts, and normalizes the publication date of an online article or blog post [@articleDateExtractor],
-- ``date_guesser`` extracts publication dates from a web pages along with an accuracy measure which is not tested here [@dateguesser],
+- ``date_guesser`` extracts publication dates from web pages along with an accuracy measure which is not tested here [@dateguesser],
 - ``goose3`` can extract information for embedded content [@goose3],
 - ``htmldate`` is the software package described here; it is designed to extract original and updated publication dates of web pages [@Barbaresi:2019],
 - ``newspaper`` is mostly geared towards newspaper texts [@newspaper],


### PR DESCRIPTION
Closes #6.

## Summary
- fix a grammar issue in the contributor guide
- fix two `from a web pages` wording issues in the evaluation docs and JOSS article source
- fix a typo in the JOSS article source

## Verification
- `git diff --check`
- searched the touched files for the corrected strings: `thouroughly`, `from a web pages`, and `Help making`