### PR TITLE
fix: prefer JSON-LD data over lower-confidence header reserve dates

### DIFF
--- a/htmldate/core.py
+++ b/htmldate/core.py
@@ -252,6 +252,20 @@ def examine_header(
     :return: Returns a valid date expression as a string, or None
 
     """
+    headerdate, reserve = examine_header_candidates(tree, options)
+    # if nothing was found, look for lower granularity (so far: "copyright year")
+    if headerdate is None and reserve is not None:
+        LOGGER.debug("opting for reserve date with less granularity")
+        headerdate = reserve
+    return headerdate
+
+
+def examine_header_candidates(
+    tree: HtmlElement,
+    options: Extractor,
+) -> tuple[str | None, str | None]:
+    """Parse header elements and return the matching date along with a
+    lower-confidence reserve date, if any."""
     headerdate, reserve = None, None
     tryfunc = partial(
         try_date_expr,
@@ -348,12 +362,7 @@ def examine_header(
         # exit loop
         if headerdate is not None:
             break
-    # if nothing was found, look for lower granularity (so far: "copyright year")
-    if headerdate is None and reserve is not None:
-        LOGGER.debug("opting for reserve date with less granularity")
-        headerdate = reserve
-    # return value
-    return headerdate
+    return headerdate, reserve
 
 
 def select_candidate(
@@ -872,7 +881,9 @@ def find_date(
 
     # first try header
     # then try to use JSON data
-    result = examine_header(tree, options) or json_search(tree, options)
+    # a header reserve date is lower-confidence than JSON-LD, so try JSON first
+    header_result, header_reserve = examine_header_candidates(tree, options)
+    result = header_result or json_search(tree, options) or header_reserve
     if result is not None:
         return result
 

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -784,6 +784,22 @@ def test_free_text_timezone():
     assert find_date(freetext, original_date=True) == "2024-11-06"
 
 
+def test_json_over_header_reserve():
+    """A lower-confidence header reserve date must not take precedence over
+    JSON-LD data (issue #195)."""
+    htmlstring = (
+        "<html><head>"
+        '<meta property="article:modified_time" content="2020-07-20"/>'
+        '<script type="application/ld+json">'
+        '{"@type":"Article","datePublished":"2020-07-01",'
+        '"dateModified":"2020-07-20"}</script>'
+        "</head><body><p>text</p></body></html>"
+    )
+    assert find_date(htmlstring, original_date=True) == "2020-07-01"
+    # the modified date is still returned when it is the one requested
+    assert find_date(htmlstring, original_date=False) == "2020-07-20"
+
+
 def test_is_valid_date():
     """test internal date validation"""
     assert (


### PR DESCRIPTION
Closes #195

`examine_header()` folded its lower-confidence `reserve` date into its return value, so `find_date()` saw a truthy result from a fallback meta property (e.g. `article:modified_time`, stored as reserve when `original_date=True`) and the `or json_search(...)` branch never ran — the JSON-LD `datePublished` was ignored.

The header scan now returns the match and the reserve separately, and `find_date()` consults JSON-LD before falling back to the reserve. `examine_header()` keeps its existing signature and behaviour for external callers.

Regression test added in `tests/unit_tests.py`; it fails on master and passes with the fix. The two pre-existing `test_input`/`test_exact_date` failures are unchanged from baseline.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
