### PR TITLE
fix: prefer JSON-LD dates over less reliable header fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 
 ## 1.x.x
+- fix: prefer JSON-LD dates over less reliable header fallbacks (#195)
 - breaking: CLI now defaults to extensive search, `-f/--fast` enables fast mode (previously inverted)
 - fix: parse month names regardless of case (e.g. uppercase Turkish), no more crash
 - performance: fixes for regex backtracking and other DoS vectors, working candidate-filter cache

--- a/htmldate/core.py
+++ b/htmldate/core.py
@@ -276,6 +276,32 @@ def examine_header(
     :return: Returns a valid date expression as a string, or None
 
     """
+    headerdate, reserve = examine_header_dates(tree, options)
+    # if nothing was found, look for lower granularity (so far: "copyright year")
+    if headerdate is None and reserve is not None:
+        LOGGER.debug("opting for reserve date with less granularity")
+        headerdate = reserve
+    return headerdate
+
+
+def examine_header_dates(
+    tree: HtmlElement,
+    options: Extractor,
+) -> tuple[str | None, str | None]:
+    """
+    Parse header elements to find date cues, keeping the matching date and the
+    less reliable fallback ("reserve") date apart
+
+    :param tree:
+        LXML parsed tree object
+    :type tree: LXML tree
+    :param options:
+        Options for extraction
+    :type options: Extractor
+    :return: Returns a tuple of the matching date and the reserve date, as
+        valid date expressions or None
+
+    """
     headerdate, reserve = None, None
     tryfunc = partial(try_date_expr_opts, options=options)
     # loop through all meta elements
@@ -361,12 +387,8 @@ def examine_header(
         # exit loop
         if headerdate is not None:
             break
-    # if nothing was found, look for lower granularity (so far: "copyright year")
-    if headerdate is None and reserve is not None:
-        LOGGER.debug("opting for reserve date with less granularity")
-        headerdate = reserve
-    # return value
-    return headerdate
+    # return values
+    return headerdate, reserve
 
 
 def select_candidate(
@@ -830,7 +852,11 @@ def find_date(
 
     # first try header
     # then try to use JSON data
-    result = examine_header(tree, options) or json_search(tree, options)
+    # a header "reserve" date is a low-confidence fallback (e.g. a modification
+    # date when the original one was requested): only use it if JSON-LD, which
+    # can carry the requested date explicitly, has nothing to offer
+    header_result, header_reserve = examine_header_dates(tree, options)
+    result = header_result or json_search(tree, options) or header_reserve
     if result is not None:
         return result
 

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -746,6 +746,35 @@ def test_exact_date():
     )
 
 
+def test_json_ld_over_header_reserve():
+    """A less reliable header date must not shadow an explicit JSON-LD date
+    (issue #195)."""
+    htmlstring = (
+        "<html><head>"
+        '<meta property="article:modified_time" content="2023-05-20T12:00:00+00:00"/>'
+        '<script type="application/ld+json">'
+        '{"@context":"https://schema.org","@type":"Article",'
+        '"datePublished":"2020-01-15T08:00:00+00:00",'
+        '"dateModified":"2023-05-20T12:00:00+00:00"}'
+        "</script></head><body><p>text</p></body></html>"
+    )
+    # the modification date is only a fallback here: JSON-LD has the original one
+    assert find_date(htmlstring, original_date=True) == "2020-01-15"
+    # the modification date is what was asked for, header result still wins
+    assert find_date(htmlstring, original_date=False) == "2023-05-20"
+
+    # without a JSON-LD alternative the header fallback is still used
+    assert (
+        find_date(
+            "<html><head>"
+            '<meta property="article:modified_time" content="2023-05-20T12:00:00+00:00"/>'
+            "</head><body><p>text</p></body></html>",
+            original_date=True,
+        )
+        == "2023-05-20"
+    )
+
+
 def test_free_text_timezone():
     """Time of day and time zone must be preserved when dates are extracted
     from free text / JSON via regexes (issue #174)."""


### PR DESCRIPTION
Closes #195

`find_date()` ran `examine_header()` before `json_search()`, but `examine_header()` folds its low-confidence "reserve" date into its return value — for example a modification date picked up while `original_date=True` was requested. Any such fallback short-circuited the JSON-LD lookup, so a page carrying both an `article:modified_time` meta element and a JSON-LD `datePublished` returned the modification date even when the original one was asked for.

`examine_header()` now delegates to a new `examine_header_dates()` helper returning the matching and reserve dates separately, and `find_date()` tries JSON-LD before falling back to the reserve date. `examine_header()`'s own behaviour and signature are unchanged. The added test fails on master and passes with the fix.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
